### PR TITLE
client: Show all sample ids for grouped samples in grapetree view

### DIFF
--- a/client/app/blueprints/cluster/static/js/tree/d3_m_tree.js
+++ b/client/app/blueprints/cluster/static/js/tree/d3_m_tree.js
@@ -1043,9 +1043,7 @@ D3MSTree.prototype._setNodeText = function(){
     if (! this.show_node_labels){
         return;
     }
-    var node_text = this.node_elements.filter(function(d){
-        return (!d.hypothetical || self.show_hypothetical_nodes);
-    }).
+    var node_text = this.node_elements.filter(node => (!node.hypothetical || self.show_hypothetical_nodes))
     append('text').attr('class', 'node-group-number').
     attr('dy', ".71em").attr('text-anchor', 'middle').attr('font-size', this.node_font_size).
     attr('font-family', 'sans-serif').attr('transform', function(it){
@@ -1062,7 +1060,6 @@ D3MSTree.prototype._setNodeText = function(){
         }
 	var all_ids_html = grouped[it.id].join(',');
 	return all_ids_html;
-            //return it.id;
 }).call(wrap, 100);
 
 
@@ -1075,7 +1072,7 @@ function wrap(text, width) {
         line = [],
         lineHeight = 1, // ems
         y = text.attr("y")-8*words.length,
-		lnum=1,
+	lnum=1,
         dy = parseFloat(text.attr("dy")),
         tspan = text.text(null).append("tspan").attr("x", 0).attr("y", y).attr("dy", dy + "em");
     while (word = words.pop()) {


### PR DESCRIPTION
Fixes #38 

This update lifts over Björns modified code from grapetree@lennart to enable the display of multiple sample ids for nodes that that group samples.

To test this, set up a dev instance of bonsai and load multiple samples into the db. Samples labelled with "TestHamilton" are good candidates for grouped nodes in grapetree.  In grapetree, select  "Tree layout" -> "Node style" -> check "Show Labels".

Ensure that all sample ids are displayed in grouped nodes. Ensure that there are no javascript errors.

This update does not fix the issue detailed in #38 :

> In old cgviz the multi labels are only displayed on the first click of "Show labels", on subsequent changes to label options the labels are merged into one
