### PR TITLE
Pinned Flask and werkzeug versions

### DIFF
--- a/client/setup.py
+++ b/client/setup.py
@@ -11,7 +11,8 @@ setup(
    install_requires=[
     'setuptools',
     'wheel',
-    'Flask',
+    'Flask<=2.3.3',
+    'werkzeug<=2.3.7',
     "flask-login",
     "requests",
     "pydantic",


### PR DESCRIPTION
Fixes the crash caused by flask-login being incompatible with Flask v3

Closes #61 