### PR TITLE
Unset default limit of 20 samples when gathering metadata for grapetree data

### DIFF
--- a/client/app/blueprints/cluster/views.py
+++ b/client/app/blueprints/cluster/views.py
@@ -142,7 +142,7 @@ def cluster_and_display_tree():
             flash(str(error), "danger")
         else:
             # get metadata
-            samples = get_samples_by_id(token, sample_ids=sample_ids)
+            samples = get_samples_by_id(token, sample_ids=sample_ids, limit = 0)
             metadata = gather_metadata(samples["records"])
             # query for sample metadata
             data = dict(nwk=newick, **metadata.dict())


### PR DESCRIPTION
Closes #39 

This tiny fix ensures that metadata is returned for all queried samples when gathering metadata clustering, instead of just the 20 first samples.

### How to setup and perform the tests

1. Setup bonsai instance and add N > 20 samples to the database
2. Login, add N > 20 samples to the basket 
3. Open basket and select Cluster
4. In the grapetree view, right click the tree and select `show metadata table` 
5. Confirm that metadata is displayed for all samples and not just the 20 first

### Expected outcome 

The table should be populated with metadata for all samples, not just the first 20 samples.