### PR TITLE
Fixed sample table reaching outside containing dom element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Fixed padding of sample table in group and groups view.
+
 ## [v0.8.0]
 
 ### Added

--- a/frontend/bonsai_app/blueprints/groups/static/group.css
+++ b/frontend/bonsai_app/blueprints/groups/static/group.css
@@ -6,7 +6,7 @@
 .br-main {
   display: flex;
   flex-direction: column;
-  height: calc(100vh - 8rem);
+  height: max(100%, calc(100vh - 8rem));
 }
 
 #data-table {

--- a/frontend/bonsai_app/blueprints/groups/static/groups.css
+++ b/frontend/bonsai_app/blueprints/groups/static/groups.css
@@ -42,7 +42,7 @@
 .br-main {
   display: flex;
   flex-direction: column;
-  height: calc(100vh - 8rem);
+  height: max(100%, calc(100vh - 8rem));
 }
 
 #data-table {

--- a/frontend/bonsai_app/blueprints/groups/templates/group.html
+++ b/frontend/bonsai_app/blueprints/groups/templates/group.html
@@ -14,7 +14,7 @@
 {% endblock scripts %}
 
 {% block content %}
-<div class="card bg-white mt-4 col-lg-auto mx-2">
+<div class="card bg-white mt-2 col-lg-auto mx-2">
     <div class="card-body br-main">
         <h4 class="card-title me-auto fw-light">{{group_name}}</h4>
         <hr class="mt-2 col-md-2 border border-success border-2">

--- a/frontend/bonsai_app/blueprints/groups/templates/groups.html
+++ b/frontend/bonsai_app/blueprints/groups/templates/groups.html
@@ -14,7 +14,7 @@
 {% endblock scripts %}
 
 {% block content %}
-<div class="card bg-white mt-4 col-lg-auto mx-2">
+<div class="card bg-white mt-2 col-lg-auto mx-2">
     <div class="card-body br-main">
         <h5 class="card-title text-uppercase fw-light">Groups</h5>
         <hr class="mt-2 col-md-2 border border-success border-2">


### PR DESCRIPTION
This PR fixes a graphical issue where the sample table could reach outside its containing HTML DOM element.

![foo](https://github.com/user-attachments/assets/57eb719b-f889-47dd-b32f-04669cce42a7)
