### PR TITLE
Update AMR report in LIMS export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@
 
 ### Changed
 
-- Added dummy SKA indexes for test samples
+- Added dummy SKA indexes for test samples.
 - Updated PRP to version 0.11.3
+- Added underscores to AMRs in LIMS export.
 
 ### Fixed
 

--- a/api/bonsai_api/io.py
+++ b/api/bonsai_api/io.py
@@ -245,7 +245,7 @@ def _fmt_mtuberculosis(sample: SampleInDatabase):
                 result.append(
                     {
                         "sample_id": sample.sample_name,
-                        "parameter": f"{info['abbrev'].upper()} NGS",
+                        "parameter": f"{info['abbrev'].upper()}_NGS",
                         "result": call,
                         "variants": variants,
                     }

--- a/api/tests/test_io.py
+++ b/api/tests/test_io.py
@@ -17,3 +17,13 @@ def test_sample_to_kmlims(mtuberculosis_sample):
     # test that,
     # the targeted antibiotics were reported
     assert len(result) == n_exp_antibiotics + 3  # + lineage, qc, and spp pred
+
+    # test that valid parameter codes are used
+    VALID_PARAMS = ('RIF_NGS', 'INH_NGSH', 'INH_NGSL', 'PYR_NGS', 'ETB_NGS', 'AMI_NGS', 'LEV_NGS', 'MTBC_QC', 'MTBC_ART', 'MTBC_LINEAGE')
+    matched_params = (
+        result
+        .assign(matched=lambda col: col['parameter'].apply(lambda param: param in VALID_PARAMS))
+        .set_index('parameter')
+        .loc[:,'matched']
+        )
+    assert matched_params.all()

--- a/frontend/bonsai_app/blueprints/sample/views.py
+++ b/frontend/bonsai_app/blueprints/sample/views.py
@@ -280,7 +280,7 @@ def download_lims(sample_id: str):
     buffer = BytesIO(data.encode("UTF-8"))
     response = make_response(buffer.getvalue())
     # define headers and mimetype for a file
-    response.headers["Content-Disposition"] = f"attachment; filename={fname}.tsv"
+    response.headers["Content-Disposition"] = f"attachment; filename={fname}.txt"
     response.mimetype = "text/csv"
     # return response object
     return response


### PR DESCRIPTION
This PR updates the format AMR resistance in the LIMS export. 

From `RIF NGS` to `RIF_NGS`.

The test also adds a new test for checking compliance.
