### PR TITLE
Fixes issues where virulence predictions and resfinder results was not displayed properly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Fixed
 
 - Fixed padding of sample table in group and groups view.
+- Fixed issue preventing virulence predictions to be shown.
 
 ## [v0.8.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Fixed padding of sample table in group and groups view.
 - Fixed issue preventing virulence predictions to be shown.
+- Fixed display issues of ResFinder variants.
 
 ## [v0.8.0]
 

--- a/frontend/bonsai_app/blueprints/sample/templates/cards.html
+++ b/frontend/bonsai_app/blueprints/sample/templates/cards.html
@@ -186,7 +186,7 @@
 <div class="card">
     <div class="card-header">{{ pred.software | capitalize }} [ <i>{{pred.type}}</i> ]</div>
     <div class="card-body">
-    {% if pred.genes | length == 0 %}
+    {% if pred.result.genes | length == 0 %}
         <p class="card-text fst-italic">No  identified virulence factors.</p>
     {% elif pred.software == "virulencefinder" %}
         {{ virulencefinder_prediction(pred.result) }}

--- a/frontend/bonsai_app/blueprints/sample/templates/cards.html
+++ b/frontend/bonsai_app/blueprints/sample/templates/cards.html
@@ -402,6 +402,7 @@
             <thead>
                 <tr>
                     <td scope="col">Variant</td>
+                    <td scope="col">Type</td>
                     <td scope="col">Gene</td>
                     <td scope="col">Protein change</td>
                     <td scope="col">Depth</td>
@@ -411,8 +412,9 @@
             <tbody class="table-group-divider">
                 {% for variant in result.variants %}
                     <tr>
-                        <td>{{ variant.name }}</td>
-                        <td>{{ accession_link(variant.close_seq_name, name=variant.gene_symbol) }}</td>
+                        <td>{{ variant.ref_nt }}{{ variant.start }}{{ variant.alt_nt }}</td>
+                        <td>{{ variant.variant_type }}</td>
+                        <td>{{ accession_link(variant.accession, name=variant.reference_sequence) }}</td>
                         <td>{{ variant.ref_aa | upper }}>{{variant.alt_aa | upper }}</td>
                         <td>{{ variant.depth | fmt_number }}</td>
                         <td>{{ variant.phenotypes | get_resistance_profile(level="name") }}</td>


### PR DESCRIPTION
This PR fixes to issues on the samples view that prevented virulencefinder and resfinder results form being properly displayed.

### How to setup and perform the tests

1. Checkout branch locally.
2. Setup and bootstrap a new version of bonsai, `docker compose -f docker-compose.yml -f docker-compose.e2e_test.yml -f docker-compose.dev.yml up -d`
3. Log in as the admin user
4. Goto http://localhost:8000/sample/DRR237264

### Expected outcome 

 - Virulence predictions from virulencefinder and amrfinder should be visible 
 - Resfinder variants should be properly formatted

### Additional context
