### PR TITLE
Prevent groups without added samples display all samples in the db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed
 
+- Empty groups of samples are now being displayed as being empty.
 - Dates are now being handled properly in the sample tables.
 - Fixed padding of sample table in group and groups view.
 - Fixed issue preventing virulence predictions to be shown.

--- a/api/bonsai_api/crud/sample.py
+++ b/api/bonsai_api/crud/sample.py
@@ -284,16 +284,7 @@ async def get_samples_summary(
         facet_pipe.append({"$limit": limit})
     if skip > 0:
         facet_pipe.append({"$skip": skip})
-    """
-    pipeline.append(
-        {
-            "$facet": {
-                "data": facet_pipe,
-                "records_total": [{"$count": "count"}],
-            }
-        },
-    )
-    """
+
     pipeline.append(
         {
             "$facet": {

--- a/api/bonsai_api/crud/sample.py
+++ b/api/bonsai_api/crud/sample.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Sequence
 
 from bson.objectid import ObjectId
 from fastapi.encoders import jsonable_encoder
+from motor.motor_asyncio import AsyncIOMotorCommandCursor
 from prp.models import PipelineResult
 from prp.models.phenotype import AnnotationType, ElementType, PhenotypeInfo
 from prp.models.tags import TagList
@@ -206,10 +207,9 @@ async def get_samples_summary(
 ) -> List[SampleSummary]:
     """Get a summay of several samples."""
     # build query pipeline
-    pipeline = []
-    if include_samples is not None and len(include_samples) > 0:
+    pipeline: list[dict[str, Any]] = []
+    if isinstance(include_samples, list) and len(include_samples) > 0:
         pipeline.append({"$match": {"sample_id": {"$in": include_samples}}})
-
     # species prediction projection
     # get the first entry of the bracken result
     spp_cmd = {
@@ -279,7 +279,7 @@ async def get_samples_summary(
     pipeline.append({"$project": {**base_projection, **optional_projecton}})
 
     # add limit, skip and count total records in db
-    facet_pipe = []
+    facet_pipe: list[dict[str, int]] = []
     if limit > 0:
         facet_pipe.append({"$limit": limit})
     if skip > 0:
@@ -294,20 +294,27 @@ async def get_samples_summary(
         },
     )
 
-    # query database
-    cursor = db.sample_collection.aggregate(pipeline)
-    # get query results from the database
-    results = await cursor.to_list(None)
-    result = results[0]
+    if isinstance(include_samples, list) and len(include_samples) == 0:
+        # avoid query if include_samples is set and is empty.
+        query_response = MultipleRecordsResponseModel(
+            data=[],
+            records_total=0
+        )
+    else:
+        # query database for the number of samples
+        cursor: AsyncIOMotorCommandCursor = db.sample_collection.aggregate(pipeline)
 
-    return MultipleRecordsResponseModel(
-        data=result["data"],
-        records_total=(
-            0
-            if len(result["records_total"]) == 0
-            else result["records_total"][0]["count"]
-        ),
-    )
+        # get query results from the database
+        query_results: list[dict[str, Any]] = await cursor.to_list(None)
+        query_response = MultipleRecordsResponseModel(
+            data=query_results[0]["data"],
+            records_total=(
+                0
+                if len(query_results[0]["records_total"]) == 0
+                else query_results[0]["records_total"][0]["count"]
+            ),
+        )
+    return query_response
 
 
 async def get_samples(

--- a/api/bonsai_api/models/base.py
+++ b/api/bonsai_api/models/base.py
@@ -58,8 +58,16 @@ class MultipleRecordsResponseModel(RWModel):  # pylint: disable=too-few-public-m
     """Generic response model for multiple data records."""
 
     data: list[dict[str, Any]] = Field(...)
-    records_total: int = Field(..., alias="recordsTotal")
+    records_total: int = Field(
+        ..., alias="recordsTotal", 
+        description="Number of db records matching the query",
+    )
 
     @computed_field(alias="recordsFiltered")
     def records_filtered(self) -> int:
+        """
+        Number of db returned records after narrowing the result.
+        
+        The result can be reduced with limit and skip operations etc.
+        """
         return len(self.data)

--- a/api/bonsai_api/routers/samples.py
+++ b/api/bonsai_api/routers/samples.py
@@ -107,7 +107,7 @@ async def samples_summary(
     skip: int = Query(0, gt=-1),
     prediction_result: bool = Query(True, description="Include prediction results"),
     qc_metrics: bool = Query(False, description="Include QC metrics"),
-    sid: list[str] = Query([], description="Optional limit query to samples ids"),
+    sid: list[str] | None = Query(None, description="Optional limit query to samples ids"),
     db: Database = Depends(get_db),
     current_user: UserOutputDatabase = Security(  # pylint: disable=unused-argument
         get_current_active_user, scopes=[READ_PERMISSION]

--- a/e2e_tests/tests/views/test_group.py
+++ b/e2e_tests/tests/views/test_group.py
@@ -23,7 +23,7 @@ def test_open_group_view(logged_in_user, config, group_id: str):
     assert "bonsai" in logged_in_user.title.lower()
 
 
-@pytest.mark.parametrize("group_id", ["mtuberculosis", "saureus", "ecoli"])
+@pytest.mark.parametrize("group_id", ["mtuberculosis", "saureus"])
 def test_open_qc_view(logged_in_user, config, group_id: str):
     """Test the QC view could be opended for the different test groups."""
 
@@ -38,7 +38,7 @@ def test_open_qc_view(logged_in_user, config, group_id: str):
     assert "bonsai" in logged_in_user.title.lower()
 
 
-@pytest.mark.parametrize("group_id", ["mtuberculosis", "saureus", "ecoli"])
+@pytest.mark.parametrize("group_id", ["mtuberculosis", "saureus"])
 def test_add_samples_to_basket(logged_in_user, config, group_id: str):
     """Test the QC view could be opended for the different test groups."""
 
@@ -86,3 +86,19 @@ def test_add_samples_to_basket(logged_in_user, config, group_id: str):
     # TEST that one sample has been added to the basket
     counter = get_element_by_test_id(logged_in_user, "samples-in-basket-counter")
     assert counter.text == "5"
+
+
+def test_empty_group_is_empty(logged_in_user, config):
+    """Test that no samples are being displayed in an empty group."""
+    # go to the ecoli group view
+    logged_in_user.get(str(Path(config["frontend_url"]) / "groups" / "ecoli"))
+
+    # verify that no samples are being displayed in the table
+    samples_counter = logged_in_user.find_element(By.ID, "samples-counter")
+    assert int(samples_counter.text) == 0
+
+    # get sample table
+    sample_table = logged_in_user.find_element(By.ID, "sample-table")
+
+    # verify that the number of samples in the group is 0
+    assert sample_table.text.startswith('No data available')

--- a/frontend/bonsai_app/blueprints/groups/templates/group.html
+++ b/frontend/bonsai_app/blueprints/groups/templates/group.html
@@ -22,7 +22,9 @@
         <table class="table table-sm w-auto">
             <thead><tr><th>Samples</th><th>Updated</th></tr></thead>
             <tbody>
-                <tr><td>{{ table_data | length }}</td><td>{{ modified | strftime }}</td></tr>
+                <tr>
+                    <td id="samples-counter">{{ table_data | length }}</td>
+                    <td id="group-modified-timestamp">{{ modified | strftime }}</td></tr>
             </tbody>
         </table>
         <nav class="navbar bg-light">


### PR DESCRIPTION
This PR fixes a bug that caused empty sample groups to display all samples in the database.