### PR TITLE
Droped connection to redis no longer crashes the sample view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- A redis connection error no longer crash the sample view in the frontend.
+
 ## [v1.0.0]
 
 ### Added

--- a/api/bonsai_api/redis/__init__.py
+++ b/api/bonsai_api/redis/__init__.py
@@ -1,3 +1,4 @@
 """Module for setting up the redis queue and scheduling jobs."""
 
+from redis.exceptions import ConnectionError
 from .models import ClusterMethod, MsTreeMethods, SubmittedJob

--- a/frontend/bonsai_app/blueprints/sample/templates/sample.html
+++ b/frontend/bonsai_app/blueprints/sample/templates/sample.html
@@ -49,7 +49,9 @@
             <hr class="mt-2 col-md-3 border border-success border-2">
             <div id="epi-typing-heading" class="row justify-content-md-center">
                 <div class="col-md-auto">
-                    {{ similar_samples_card(similar_samples) }}
+                    {% if simiar_samples is defined %}
+                        {{ similar_samples_card(similar_samples) }}
+                    {% endif %}
                 </div>
                 {% for res in sample.typing_result %}
                     {% if res.type == "mlst" %}


### PR DESCRIPTION
This PR fixes an issue where a the samples view in the frontend would crash if a connection to the redis server could not be made.

Visual error message

![bild](https://github.com/user-attachments/assets/1058ec01-b7ef-4330-9fb3-54c497f79600)

Errors in the logs

![bild](https://github.com/user-attachments/assets/650cc2fb-9850-4819-af85-b93db736cc03)


### How to setup and perform the tests

1. Add the following environment variable to the api service in the `docker-compose.dev.yml`.
```yaml
    environment:
      - REDIS_HOST=failed_redis
```
2. Bring up a new Bonsai instance, `docker compose -f docker-compose.yml -f docker-compose.e2e_test.yml -f docker-compose.dev.yml up -d`
3. Login and go to http://localhost:8000/sample/DRR237262
4. There should now be a warning that finding similar samples failed
5. Check the frontend logs, `docker compose -f docker-compose.yml -f docker-compose.e2e_test.yml -f docker-compose.dev logs frontend` for a more informative error message.