### PR TITLE
Fixed extraction of version numbers in workflow

### DIFF
--- a/.github/workflows/publish_docker_on_release.yml
+++ b/.github/workflows/publish_docker_on_release.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Export tags to env
         run: |
-          FRONTEND_VERSION=$(head -2 frontend/app/__version__.py | tail -1 | cut -d'"' -f2);
+          FRONTEND_VERSION=$(tail -1 frontend/bonsai_app/__version__.py | cut -d'"' -f2);
           echo "TOOL_VERSION=${FRONTEND_VERSION}" >> $GITHUB_ENV
           echo "TAG_LATEST=latest" >> $GITHUB_ENV
 
@@ -60,7 +60,7 @@ jobs:
 
       - name: Export tags to env
         run: |
-          API_VERSION=$(head -3 api/app/__version__.py | tail -1 | cut -d'"' -f2);
+          API_VERSION=$(tail -1 api/bonsai_api/__version__.py | cut -d'"' -f2);
           echo "TOOL_VERSION=${API_VERSION}" >> $GITHUB_ENV
           echo "TAG_LATEST=latest" >> $GITHUB_ENV
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Fixed
+
+- Fixed workflow for publishing docker images on tagged releases.
+
 ## [v.1.2.0]
 
 ### Added


### PR DESCRIPTION
This PR fixes the workflow for pushing tagged versions of the docker images on new releases.

See workflow test run: https://github.com/SMD-Bioinformatics-Lund/bonsai/actions/runs/15636128691