### PR TITLE
Show reason for failed qc on hover in the sample table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### Changed
 
+- Entrypoint GET `/samples` was changed to POST `/samples/summary` to mitigate URL length limitations.
 - Moved javascript from jinja templates into typescript modules and refactored some page elements into web components.
 - Updated `WebDriverWait` time in e2e tests.
 - Updated minhash error throwing for missing sig files

--- a/api/bonsai_api/cli/cli.py
+++ b/api/bonsai_api/cli/cli.py
@@ -1,11 +1,10 @@
 """Commmand line interface to server component."""
 
 import asyncio
-from bson import json_util
 import pathlib
 from io import StringIO, TextIOWrapper
 from logging import getLogger
-from typing import Any, Callable
+from typing import Callable
 
 import click
 from bonsai_api.__version__ import VERSION as version
@@ -15,7 +14,6 @@ from bonsai_api.crud.group import create_group as create_group_in_db
 from bonsai_api.crud.sample import get_sample, get_samples, update_sample
 from bonsai_api.crud.tags import compute_phenotype_tags
 from bonsai_api.crud.user import create_user as create_user_in_db
-from bonsai_api.crud.utils import get_deprecated_records
 from bonsai_api.db import verify
 from bonsai_api.db.index import INDEXES
 from bonsai_api.db.utils import get_db_connection
@@ -23,8 +21,7 @@ from bonsai_api.io import sample_to_kmlims
 from bonsai_api.models.group import GroupInCreate, pred_res_cols
 from bonsai_api.models.sample import MultipleSampleRecordsResponseModel, SampleInCreate
 from bonsai_api.models.user import UserInputCreate
-from prp.models.sample import SCHEMA_VERSION
-from prp.migration.convert import migrate_result
+from bonsai_api.migrate import migrate_sample_collection, migrate_group_collection, MigrationError
 from pymongo.errors import DuplicateKeyError
 
 from .utils import EmailType, create_missing_file_report, send_email_report
@@ -284,39 +281,11 @@ def migrate_database(backup_path: pathlib.Path | None):
     # 1 query the database for all samples that does not have the current schema version
     loop = asyncio.get_event_loop()
     with get_db_connection() as db:
-        if db.sample_collection is None:
-            raise ValueError
-        func = get_deprecated_records(db.sample_collection, SCHEMA_VERSION)
-        samples: list[dict[str, Any]] = loop.run_until_complete(func)
-
-        # 2 summarize operation
-        if len(samples) == 0:
-            click.secho("Your database is up to date!", fg="green")
-            raise click.Abort()
-
-        click.secho(f"Found {click.style(len(samples), fg='cyan', bold=True)} entry to migrate.")
-
-        # Confirm migration
-        click.confirm('Do you what to continue?', abort=True)
-
-        # 3 migrate data and validate using the current schema
-        migrated_samples: list[SampleInCreate] = [
-            SampleInCreate.model_validate(
-                migrate_result(sample, validate=False)
-            ) for sample in samples
-        ]
-        # 4 backup old records as json array
-        if backup_path is not None:
-            click.secho(f"Backing up old entries to: {backup_path}")
-            with open(backup_path, 'w', encoding='utf-8') as outf:
-                outf.write(json_util.dumps(samples, indent=3))
-        # 5 update samples
-        click.secho(f"Updating samples in the database")
         try:
-            for upd_sample in migrated_samples:
-                func = update_sample(db, upd_sample)
-                was_updated = loop.run_until_complete(func)
-                if not was_updated:
-                    raise ValueError(f"Sample '{upd_sample.sample_id}' was not updated.")
+            for mig_func in [migrate_sample_collection, migrate_group_collection]:
+                loop.run_until_complete(mig_func(db, backup_path))
+        except MigrationError as err:
+            LOG.error(str(err))
+            click.Abort()
         finally:
             click.secho("Finished migrating the database", fg="green")

--- a/api/bonsai_api/cli/cli.py
+++ b/api/bonsai_api/cli/cli.py
@@ -122,7 +122,7 @@ def create_group(
         group_id=group_id,
         display_name=name,
         description=description,
-        table_columns=pred_res_cols,
+        table_columns=[col.id for col in pred_res_cols],
         validated_genes=None
     )
     try:

--- a/api/bonsai_api/crud/group.py
+++ b/api/bonsai_api/crud/group.py
@@ -6,12 +6,11 @@ from typing import Any
 from prp.models.typing import TypingMethod
 from pymongo import ASCENDING
 
-from ..db import Database
-from ..models.group import GroupInCreate, GroupInfoDatabase
-from ..models.sample import SampleSummary
-from ..utils import get_timestamp
+from bonsai_api.db import Database
+from bonsai_api.models.group import GroupInCreate, GroupInfoDatabase
+from bonsai_api.models.sample import SampleSummary
+from bonsai_api.utils import get_timestamp
 from .errors import EntryNotFound, UpdateDocumentError
-from .sample import get_sample
 from .tags import compute_phenotype_tags
 
 LOG = logging.getLogger(__name__)

--- a/api/bonsai_api/crud/metadata.py
+++ b/api/bonsai_api/crud/metadata.py
@@ -4,7 +4,7 @@ from typing import Any
 from pydantic import TypeAdapter
 from pymongo.results import UpdateResult
 
-from bonsai_api.models.group import SampleTableColumn
+from bonsai_api.models.group import SampleTableColumnInput
 from bonsai_api.db import Database
 from bonsai_api.models.metadata import InputMetaEntry, MetaEntriesInDb, MetaEntryInDb
 from bonsai_api.io import parse_metadata_table
@@ -68,7 +68,7 @@ async def get_metadata_fields_for_samples(
             uniq_obj[meta.fieldname] = meta
 
     cols = [
-        SampleTableColumn(
+        SampleTableColumnInput(
             id=entry.fieldname.lower().replace(" ", "-"),
             label=entry.fieldname,
             path=f'$.metadata[*][?(@.fieldname = "{entry.fieldname}")].value',

--- a/api/bonsai_api/crud/metadata.py
+++ b/api/bonsai_api/crud/metadata.py
@@ -4,7 +4,7 @@ from typing import Any
 from pydantic import TypeAdapter
 from pymongo.results import UpdateResult
 
-from bonsai_api.models.group import OverviewTableColumn
+from bonsai_api.models.group import SampleTableColumn
 from bonsai_api.db import Database
 from bonsai_api.models.metadata import InputMetaEntry, MetaEntriesInDb, MetaEntryInDb
 from bonsai_api.io import parse_metadata_table
@@ -68,7 +68,7 @@ async def get_metadata_fields_for_samples(
             uniq_obj[meta.fieldname] = meta
 
     cols = [
-        OverviewTableColumn(
+        SampleTableColumn(
             id=entry.fieldname.lower().replace(" ", "-"),
             label=entry.fieldname,
             path=f'$.metadata[*][?(@.fieldname = "{entry.fieldname}")].value',

--- a/api/bonsai_api/crud/sample.py
+++ b/api/bonsai_api/crud/sample.py
@@ -201,8 +201,8 @@ QC_METRICS_SUMMARY_QUERY: list[dict[str, Any]] = [
 
 async def get_samples_summary(
     db: Database,
-    limit: int = 0,
-    skip: int = 0,
+    limit: int | None = None,
+    skip: int | None = None,
     include_samples: List[str] | None = None,
     prediction_result: bool = True,
     qc_metrics: bool = False,
@@ -286,9 +286,9 @@ async def get_samples_summary(
 
     # add limit, skip and count total records in db
     facet_pipe: list[dict[str, int]] = []
-    if limit > 0:
+    if isinstance(limit, int) and limit > 0:
         facet_pipe.append({"$limit": limit})
-    if skip > 0:
+    if isinstance(skip, int) and skip > 0:
         facet_pipe.append({"$skip": skip})
 
     pipeline.append(

--- a/api/bonsai_api/crud/utils.py
+++ b/api/bonsai_api/crud/utils.py
@@ -5,5 +5,8 @@ from motor.motor_asyncio import AsyncIOMotorCollection
 
 async def get_deprecated_records(collection: AsyncIOMotorCollection, schema_version: int) -> list[dict[str, Any]]:
     """Get documents from the collection that have a schema version."""
-    cursor = collection.find({"schema_version": {"$lt": schema_version}})
+    cursor = collection.find({"$or": [
+        {"schema_version": {"$lt": schema_version}},
+        {"schema_version": {"$exists": False}}
+    ]})
     return [dict(doc) for doc in await cursor.to_list(None)]

--- a/api/bonsai_api/migrate.py
+++ b/api/bonsai_api/migrate.py
@@ -1,0 +1,134 @@
+"""Functions for migrating the database between versions."""
+from typing import Any, Callable
+from bson import json_util
+import click
+import logging
+
+from bonsai_api.crud.utils import get_deprecated_records
+from bonsai_api.models.sample import SampleInCreate
+from bonsai_api.models.group import GroupInCreate
+from bonsai_api.models.group import SCHEMA_VERSION as GROUP_SCHEMA_VERSION
+from bonsai_api.crud.sample import update_sample
+from bonsai_api.db import Database
+from prp.models.sample import SCHEMA_VERSION as SAMPLE_SCHEMA_VERSION
+from prp.migration.convert import migrate_result as sample_migrate_result
+
+
+LOG = logging.getLogger(__name__)
+UnformattedResult = dict[str, Any]
+
+class MigrationError(Exception):
+    ...
+
+
+async def migrate_sample_collection(db: Database, backup_path: str | None):
+    """Migrate the sample collection bewteen schema versions."""
+    if db.sample_collection is None:
+        raise ValueError
+    samples: list[dict[str, Any]] = await get_deprecated_records(db.sample_collection, SAMPLE_SCHEMA_VERSION)
+
+    # 2 summarize operation
+    if len(samples) == 0:
+        click.secho("Sample collection is up to date!", fg="green")
+        return None
+
+    click.secho(f"Found {click.style(len(samples), fg='cyan', bold=True)} entry to migrate.")
+
+    # Confirm migration
+    click.confirm('Do you what to continue?', abort=True)
+
+    # 3 migrate data and validate using the current schema
+    migrated_samples: list[SampleInCreate] = [
+        SampleInCreate.model_validate(
+            sample_migrate_result(sample, validate=False)
+        ) for sample in samples
+    ]
+    # 4 backup old records as json array
+    if backup_path is not None:
+        click.secho(f"Backing up old entries to: {backup_path}")
+        with open(backup_path, 'w', encoding='utf-8') as outf:
+            outf.write(json_util.dumps(samples, indent=3))
+    # 5 update samples
+    click.secho(f"Updating samples in the database")
+    for upd_sample in migrated_samples:
+        was_updated = update_sample(db, upd_sample)
+        if not was_updated:
+            raise MigrationError(f"Sample '{upd_sample.sample_id}' was not updated.")
+
+
+def group_pre_1_to_1(group: UnformattedResult) -> UnformattedResult:
+    """Convert group object format from pre-v1 to v1."""
+    if 'schema_version' in group:
+        raise MigrationError("Invalid schema version - expected undefined field!")
+
+    LOG.info("Migrating to schema version %d", 1)
+    upd_group = copy(group)
+
+    # add schema version
+    upd_group["schema_version"] = 1
+
+    # replace SampleTableColumnInput objects with 
+
+
+def v1_to_v2(result: UnformattedResult) -> UnformattedResult:
+    """Convert result in json format from v1 to v2."""
+    input_schema_version = result["schema_version"]
+    if input_schema_version != 1:
+        raise ValueError(f"Invalid schema version '{input_schema_version}' expected 1")
+
+    LOG.info("Migrating from v%d to v%d", input_schema_version, 2)
+    upd_result = copy(result)
+    # split analysis profile into a list and strip white space
+    upd_profile: list[str] = [
+        prof.strip() for prof in result["pipeline"]["analysis_profile"].split(",")
+    ]
+    upd_result["pipeline"]["analysis_profile"] = upd_profile
+    # get assay from upd_profile
+    new_assay: str = next(
+        (
+            config.profile_array_modifiers[prof]
+            for prof in upd_profile
+            if prof in config.profile_array_modifiers
+        ),
+        None,
+    )
+    upd_result["pipeline"]["assay"] = new_assay
+    # add release_life_cycle
+    new_release_life_cycle: str = (
+        "development" if {"dev", "development"} & set(upd_profile) else "production"
+    )
+    upd_result["pipeline"]["release_life_cycle"] = new_release_life_cycle
+    # update schema version
+    upd_result["schema_version"] = 2
+    return upd_result
+
+
+
+def migrate_group(group):
+    """Migrate group documents in the database."""
+    ALL_FUNCS: dict[int, Callable[..., UnformattedResult]] = {"pre_1": group_pre_1_to_1}
+    import pdb; pdb.set_trace()
+
+
+async def migrate_group_collection(db: Database, backup_path: str | None):
+    if db.sample_group_collection is None:
+        raise ValueError
+    groups: list[dict[str, Any]] = await get_deprecated_records(db.sample_group_collection, GROUP_SCHEMA_VERSION)
+
+    # 2 summarize operation
+    if len(groups) == 0:
+        click.secho("Group collection is up to date!", fg="green")
+        return None
+
+    click.secho(f"Found {click.style(len(groups), fg='cyan', bold=True)} entry to migrate.")
+
+    # Confirm migration
+    click.confirm('Do you what to continue?', abort=True)
+
+    # 3 migrate data and validate using the current schema
+    migrated_groups: list[GroupInCreate] = [
+        GroupInCreate.model_validate(
+            group_migrate_result(group)
+        ) for group in groups
+    ]
+    import pdb; pdb.set_trace()

--- a/api/bonsai_api/models/group.py
+++ b/api/bonsai_api/models/group.py
@@ -105,7 +105,7 @@ VALID_PREDICTION_COLS: list[OverviewTableColumn] = [
         id="qc",
         label="QC",
         type="qc",
-        path="$.qc_status.status",
+        path="$.qc_status",
         sortable=True,
     ),
     OverviewTableColumn(

--- a/api/bonsai_api/models/group.py
+++ b/api/bonsai_api/models/group.py
@@ -109,7 +109,7 @@ VALID_PREDICTION_COLS: list[SampleTableColumnInput] = [
         sortable=True,
     ),
     SampleTableColumnInput(
-        id="qc",
+        id="qc_status",
         label="QC",
         type="custom",
         path="$.qc_status",
@@ -117,7 +117,7 @@ VALID_PREDICTION_COLS: list[SampleTableColumnInput] = [
         renderer="qc_status_renderer",
     ),
     SampleTableColumnInput(
-        id="profile",
+        id="analysis_profile",
         label="Analysis profile",
         path="$.profile",
         type="list",
@@ -139,21 +139,21 @@ VALID_PREDICTION_COLS: list[SampleTableColumnInput] = [
         renderer="tags_renderer",
     ),
     SampleTableColumnInput(
-        id="mlst",
+        id="mlst_typing",
         label="MLST ST",
         path="$.mlst",
         sortable=True,
         filterable=True,
     ),
     SampleTableColumnInput(
-        id="stx",
+        id="stx_typing",
         label="STX typing",
         path="$.stx",
         sortable=True,
         filterable=True,
     ),
     SampleTableColumnInput(
-        id="oh",
+        id="oh_typing",
         label="OH typing",
         path="$.oh_type",
         sortable=True,
@@ -183,7 +183,7 @@ VALID_QC_COLS = [
         sortable=True,
     ),
     SampleTableColumnInput(
-        id="qc",
+        id="qc_status",
         label="QC",
         type="custom",
         path="$.qc_status.status",
@@ -247,9 +247,9 @@ SCHEMA_VERSION: str = "1"
 class GroupInCreate(GroupBase):  # pylint: disable=too-few-public-methods
     """Defines expected input format for groups."""
 
-    #schema_version: str = Field(default=SCHEMA_VERSION, description="Version of the group schema.")
-    #table_columns: list[str] = Field(default=[], description="IDs of columns to display.")
-    table_columns: list[SampleTableColumnInput] = Field(default=[], description="IDs of columns to display.")
+    schema_version: str = Field(default=SCHEMA_VERSION, description="Version of the group schema.")
+    table_columns: list[str] = Field(default=[], description="IDs of columns to display.")
+    #table_columns: list[SampleTableColumnInput] = Field(default=[], description="IDs of columns to display.")
     validated_genes: dict[ElementType, list[str]] | None = {}
 
 

--- a/api/bonsai_api/models/group.py
+++ b/api/bonsai_api/models/group.py
@@ -1,6 +1,6 @@
 """Routes related to collections of samples."""
 
-from typing import Dict, List
+from typing import Dict, List, Literal
 
 from prp.models.phenotype import ElementType
 from pydantic import BaseModel, ConfigDict, Field
@@ -31,84 +31,83 @@ class GroupBase(IncludedSamples):  # pylint: disable=too-few-public-methods
     description: str | None = None
 
 
-class OverviewTableColumn(BaseModel):  # pylint: disable=too-few-public-methods
+class SampleTableColumn(BaseModel):  # pylint: disable=too-few-public-methods
     """Definition of how to display and function of overview table."""
 
     id: str = Field(..., description="Column id")
     label: str = Field(..., description="Display name")
     path: str = Field(..., description="JSONpath describing how to access the data")
+    type: Literal["string", "number", "date", "boolean", "custom"] = "string"
+    source: Literal["result", "metadata"] = "result"  # where the data is from, analysis result or metadata
     # display params
-    hidden: bool = False
-    type: str = Field(default="string", description="Data type")
+    renderer: str | None = None
     sortable: bool = False
     filterable: bool = False
-    filter_type: str | None = None
-    filter_param: str | None = None
 
 
-VALID_BASE_COLS: list[OverviewTableColumn] = [
-    OverviewTableColumn(
+VALID_BASE_COLS: list[SampleTableColumn] = [
+    SampleTableColumn(
         id="sample_btn",
         label="",
-        type="sample_btn",
+        type="custom",
+        renderer="sample_btn",
         path="$.sample_id",
     ),
-    OverviewTableColumn(
+    SampleTableColumn(
         id="sample_id",
         label="Sample Id",
         path="$.sample_id",
-        hidden=True,
         sortable=True,
     ),
 ]
 
 # Prediction result columns
-VALID_PREDICTION_COLS: list[OverviewTableColumn] = [
-    OverviewTableColumn(
+VALID_PREDICTION_COLS: list[SampleTableColumn] = [
+    SampleTableColumn(
         id="sample_name",
         label="Name",
         path="$.sample_name",
         sortable=True,
     ),
-    OverviewTableColumn(
+    SampleTableColumn(
         id="lims_id",
         label="LIMS id",
         path="$.lims_id",
         sortable=True,
     ),
-    OverviewTableColumn(
+    SampleTableColumn(
         id="assay",
         label="Assay",
         path="$.assay",
         sortable=True,
     ),
-    OverviewTableColumn(
+    SampleTableColumn(
         id="release_life_cycle",
         label="Release life cycle",
         path="$.release_life_cycle",
         sortable=True,
     ),
-    OverviewTableColumn(
+    SampleTableColumn(
         id="sequencing_run",
         label="Sequencing run",
         path="$.sequencing_run",
         sortable=True,
     ),
-    OverviewTableColumn(
+    SampleTableColumn(
         id="taxonomic_name",
         label="Major species",
         type="taxonomic_name",
         path="$.species_prediction.scientific_name",
         sortable=True,
     ),
-    OverviewTableColumn(
+    SampleTableColumn(
         id="qc",
         label="QC",
         type="qc",
         path="$.qc_status",
         sortable=True,
     ),
-    OverviewTableColumn(
+    SampleTableColumn(
         id="profile",
         label="Analysis profile",
         path="$.profile",
@@ -116,40 +115,40 @@ VALID_PREDICTION_COLS: list[OverviewTableColumn] = [
         sortable=True,
         filterable=True,
     ),
-    OverviewTableColumn(
+    SampleTableColumn(
         id="comments",
         label="Comments",
         type="comments",
         path="$.comments",
     ),
-    OverviewTableColumn(
+    SampleTableColumn(
         id="tags",
         label="Tags",
         type="tags",
         path="$.tags",
     ),
-    OverviewTableColumn(
+    SampleTableColumn(
         id="mlst",
         label="MLST ST",
         path="$.mlst",
         sortable=True,
         filterable=True,
     ),
-    OverviewTableColumn(
+    SampleTableColumn(
         id="stx",
         label="STX typing",
         path="$.stx",
         sortable=True,
         filterable=True,
     ),
-    OverviewTableColumn(
+    SampleTableColumn(
         id="oh",
         label="OH typing",
         path="$.oh_type",
         sortable=True,
         filterable=True,
     ),
-    OverviewTableColumn(
+    SampleTableColumn(
         id="cdate",
         label="Date",
         type="date",
@@ -160,66 +159,66 @@ VALID_PREDICTION_COLS: list[OverviewTableColumn] = [
 
 # Prediction result columns
 VALID_QC_COLS = [
-    OverviewTableColumn(
+    SampleTableColumn(
         id="sample_name",
         label="Name",
         path="$.sample_name",
         sortable=True,
     ),
-    OverviewTableColumn(
+    SampleTableColumn(
         id="sequencing_run",
         label="Sequencing run",
         path="$.sequencing_run",
         sortable=True,
     ),
-    OverviewTableColumn(
+    SampleTableColumn(
         id="qc",
         label="QC",
         type="qc",
         path="$.qc_status.status",
         sortable=True,
     ),
-    OverviewTableColumn(
+    SampleTableColumn(
         id="n50",
         label="N50",
         type="number",
         path="$.quast.n50",
         sortable=True,
     ),
-    OverviewTableColumn(
+    SampleTableColumn(
         id="n_contigs",
         label="#Contigs",
         path="$.quast.n_contigs",
         sortable=True,
     ),
-    OverviewTableColumn(
+    SampleTableColumn(
         id="median_cov",
         label="Median cov",
         path="$.postalignqc.median_cov",
         sortable=True,
     ),
-    OverviewTableColumn(
+    SampleTableColumn(
         id="n_reads",
         label="# Reads",
         type="number",
         path="$.postalignqc.n_reads",
         sortable=True,
     ),
-    OverviewTableColumn(
+    SampleTableColumn(
         id="coverage",
         label="Cov > 10",
         type="number",
         path='$.postalignqc.pct_above_x["10"]',
         sortable=True,
     ),
-    OverviewTableColumn(
+    SampleTableColumn(
         id="coverage",
         label="Cov > 30",
         type="number",
         path='$.postalignqc.pct_above_x["30"]',
         sortable=True,
     ),
-    OverviewTableColumn(
+    SampleTableColumn(
         id="missing_loci",
         label="# Missing loci",
         type="number",
@@ -236,7 +235,7 @@ qc_cols = [*VALID_BASE_COLS, *VALID_QC_COLS]
 class GroupInCreate(GroupBase):  # pylint: disable=too-few-public-methods
     """Defines expected input format for groups."""
 
-    table_columns: List[OverviewTableColumn] = Field(description="Columns to display")
+    table_columns: List[SampleTableColumn] = Field(description="Columns to display")
     validated_genes: Dict[ElementType, List[str]] | None = Field({})
 
 

--- a/api/bonsai_api/models/group.py
+++ b/api/bonsai_api/models/group.py
@@ -261,3 +261,5 @@ class GroupInfoDatabase(
 
 class GroupInfoOut(GroupBase):  # pylint: disable=too-few-public-methods
     """Defines output structure of group info."""
+
+    table_columns: list[str] = Field(default=[], description="IDs of columns to display.")

--- a/api/bonsai_api/models/group.py
+++ b/api/bonsai_api/models/group.py
@@ -242,12 +242,15 @@ VALID_QC_COLS = [
 pred_res_cols = [*VALID_BASE_COLS, *VALID_PREDICTION_COLS]
 qc_cols = [*VALID_BASE_COLS, *VALID_QC_COLS]
 
+SCHEMA_VERSION: str = "1"
 
 class GroupInCreate(GroupBase):  # pylint: disable=too-few-public-methods
     """Defines expected input format for groups."""
 
-    table_columns: List[SampleTableColumnInput] = Field(description="Columns to display")
-    validated_genes: Dict[ElementType, List[str]] | None = Field({})
+    #schema_version: str = Field(default=SCHEMA_VERSION, description="Version of the group schema.")
+    #table_columns: list[str] = Field(default=[], description="IDs of columns to display.")
+    table_columns: list[SampleTableColumnInput] = Field(default=[], description="IDs of columns to display.")
+    validated_genes: dict[ElementType, list[str]] | None = {}
 
 
 class GroupInfoDatabase(

--- a/api/bonsai_api/routers/samples.py
+++ b/api/bonsai_api/routers/samples.py
@@ -90,34 +90,41 @@ WRITE_PERMISSION = "samples:write"
 UPDATE_PERMISSION = "samples:update"
 
 
-@router.get(
-    "/samples/",
+class ApiGetSamplesDetailsInput(BaseModel):
+    """Input parameters for getting sample details."""
+
+    limit: int | None = Field(default=None, gt=-1, title="Limit the output to x samples")
+    skip: int | None = Field(default=None, gt=-1, title="Skip x samples")
+    prediction_result: bool = Field(
+        default=True, title="Include prediction results"
+    )
+    qc_metrics: bool = Field(default=False, title="Include QC metrics")
+    sid: list[str] | None = Field(
+        None, description="Optional limit query to samples ids"
+    )
+
+
+@router.post(
+    "/samples/summary",
     response_model_by_alias=False,
     response_model=MultipleRecordsResponseModel,
     tags=[RouterTags.SAMPLE],
 )
 async def samples_summary(
-    limit: int = Query(10, gt=-1),
-    skip: int = Query(0, gt=-1),
-    prediction_result: bool = Query(True, description="Include prediction results"),
-    qc_metrics: bool = Query(False, description="Include QC metrics"),
-    sid: list[str] | None = Query(
-        None, description="Optional limit query to samples ids"
-    ),
+    query: ApiGetSamplesDetailsInput,
     db: Database = Depends(get_db),
     current_user: UserOutputDatabase = Security(  # pylint: disable=unused-argument
         get_current_active_user, scopes=[READ_PERMISSION]
     ),
 ):
     """Entrypoint for getting a summary for multiple samples."""
-    # query samples
     db_obj: MultipleRecordsResponseModel = await get_samples_summary(
         db,
-        limit=limit,
-        skip=skip,
-        prediction_result=prediction_result,
-        include_samples=sid,
-        qc_metrics=qc_metrics,
+        limit=query.limit,
+        skip=query.skip,
+        prediction_result=query.prediction_result,
+        include_samples=query.sid,
+        qc_metrics=query.qc_metrics,
     )
     return db_obj
 

--- a/api/bonsai_api/routers/users.py
+++ b/api/bonsai_api/routers/users.py
@@ -26,9 +26,6 @@ LOG = logging.getLogger(__name__)
 
 router = APIRouter()
 
-DEFAULT_TAGS = [
-    "users",
-]
 OWN_USER = "users:me"
 READ_PERMISSION = "users:read"
 WRITE_PERMISSION = "users:write"
@@ -80,7 +77,7 @@ async def add_samples_to_basket(
     return basket_obj
 
 
-@router.delete("/users/basket", tags=DEFAULT_TAGS)
+@router.delete("/users/basket", tags=[RouterTags.USR])
 async def remove_samples_from_basket(
     sample_ids: list[str],
     db: Annotated[Database, Depends(get_db)],
@@ -106,7 +103,7 @@ async def remove_samples_from_basket(
     return basket_obj
 
 
-@router.get("/users/{username}", tags=DEFAULT_TAGS)
+@router.get("/users/{username}", tags=[RouterTags.USR])
 async def get_user_in_db(
     username: str,
     db: Annotated[Database, Depends(get_db)],
@@ -125,7 +122,7 @@ async def get_user_in_db(
     return user
 
 
-@router.delete("/users/{username}", tags=DEFAULT_TAGS)
+@router.delete("/users/{username}", tags=[RouterTags.USR])
 async def delete_user_from_db(
     username: str,
     db: Annotated[Database, Depends(get_db)],
@@ -149,7 +146,7 @@ async def delete_user_from_db(
     return user
 
 
-@router.put("/users/{username}", tags=DEFAULT_TAGS)
+@router.put("/users/{username}", tags=[RouterTags.USR])
 async def update_user_info(
     username: str,
     user: UserInputCreate,
@@ -175,7 +172,7 @@ async def update_user_info(
     return user
 
 
-@router.get("/users/", status_code=status.HTTP_201_CREATED, tags=DEFAULT_TAGS)
+@router.get("/users/", status_code=status.HTTP_201_CREATED, tags=[RouterTags.USR])
 async def get_users_in_db(
     db: Annotated[Database, Depends(get_db)],
     current_user: Annotated[
@@ -187,7 +184,7 @@ async def get_users_in_db(
     return users
 
 
-@router.post("/users/", status_code=status.HTTP_201_CREATED, tags=DEFAULT_TAGS)
+@router.post("/users/", status_code=status.HTTP_201_CREATED, tags=[RouterTags.USR])
 async def create_user_in_db(
     user: UserInputCreate,
     db: Annotated[Database, Depends(get_db)],

--- a/frontend/bonsai_app/blueprints/groups/controller.py
+++ b/frontend/bonsai_app/blueprints/groups/controller.py
@@ -1,0 +1,55 @@
+"""Functions used by view functions to format data."""
+
+from typing import Any
+import logging
+from jsonpath2.path import Path as jsonPath
+
+from bonsai_app.models import TableData, TableColumn, TableCell
+
+LOG = logging.getLogger(__name__)
+
+SampleInfo = dict[str, Any]
+
+
+DEFAULT_RENDERERS = {
+    "string": "text_renderer",
+    "number": "number_renderer",
+    "date": "date_renderer",
+    "boolean": "boolean_renderer",
+    "list": "list_renderer",
+}
+
+def _get_renderer(column: dict[str, Any]) -> str:
+    """Get the renderer for a given column type."""
+    if column['renderer']:
+        return column['renderer']
+    column_type = column['type']
+    if column_type == "custom":
+        # Custom renderers are expected to be defined elsewhere
+        return column['renderer'] if column['renderer'] else "text_renderer"
+    if column_type not in DEFAULT_RENDERERS:
+        LOG.warning("No default renderer for column type '%s'. Using 'text_renderer'.", column_type)
+        return "text_renderer"
+    return DEFAULT_RENDERERS[column_type]
+
+
+def _get_data(sample_info: dict[str, Any], path: str) -> str:
+    jpath = jsonPath.parse_str(path)
+    data: list[str] = [m.current_value for m in jpath.match(sample_info)]
+    return data[0] if len(data) > 0 else ""
+
+
+def format_tablular_data(data: list[dict[str, Any]], column_defs: list[dict[str, Any]]) -> TableData:
+    """Format data for display in a table."""
+    rows: list[dict[str, Any]] = []
+    for sample_info in data:
+        row: TableCell = {col["id"]: _get_data(sample_info, col["path"]) for col in column_defs}
+        if row:
+            rows.append(row)
+    table_data = TableData(
+        columns=[TableColumn(
+            id=col['id'], label=col['label'], type=col['type'], 
+            renderer=_get_renderer(col)) for col in column_defs],
+        rows=rows
+    )
+    return table_data

--- a/frontend/bonsai_app/blueprints/groups/static/edit_groups.js
+++ b/frontend/bonsai_app/blueprints/groups/static/edit_groups.js
@@ -83,18 +83,7 @@ const updateGroup = (event, method) => {
     const groupColumns = Array
         .from(list)
         .filter(column => column.querySelector('input[role="switch"]').checked)
-        .map(column => {
-            
-            return {
-                id: column['dataset'].id,
-                label: column['dataset'].label,
-                type: column['dataset'].dtype,
-                path: column['dataset'].path,
-                sortable: column.querySelector('input[name="sortable"]').checked,
-                searchable: column.querySelector('input[name="searchable"]').checked,
-                hidden: column.querySelector('input[name="hidden"]').checked
-            }
-        })
+        .map(column => column['dataset'].id)
     // parse samples and validated genes
     const samplesList = document.querySelectorAll('#added-samples-list li')
     let validatedGenes = {}

--- a/frontend/bonsai_app/blueprints/groups/templates/cell_fmt.html
+++ b/frontend/bonsai_app/blueprints/groups/templates/cell_fmt.html
@@ -1,42 +1,76 @@
-{% macro render_sampleId(sample_id, label)  %}
-    <a href={{url_for('samples.sample', sample_id=sample_id)}}>{{label}}</a>
+{% macro sample_btn_renderer(cell_info)  %}
+    <td>
+        <a href="{{ url_for('samples.sample', sample_id=cell_info) }}">Open</a>
+    </td>
 {% endmacro %}
 
-{% macro render_taxonomic_name(text)  %}
-    <span class="fw-light fst-italic">{{text}}</span>
+{% macro taxonomic_name_renderer(cell_info) %}
+    <td>
+        <span class="fw-light fst-italic">{{ cell_info }}</span>
+    </td>
 {% endmacro %}
 
-{% macro render_qc(text)  %}
-    {% if text == 'passed' %}
+{% macro qc_status_renderer(cell_info) %}
+    {% set status = cell_info.status %}
+    {% if status == 'passed' %}
         {% set text_colour = 'text-success' %}
-    {% elif text == 'failed' %} 
+    {% elif status == 'failed' %}
         {% set text_colour = 'text-danger' %}
     {% else %}
         {% set text_colour = '' %}
     {% endif %}
-    <span class="fw-light {{ text_colour }}">{{ text }}</span>
-{% endmacro %}
 
-{% macro render_mlst(st)  %}
-    {% if st == None %}
-        {% set st="-" %}
+
+    {% if cell_info.action and cell_info.comment %}
+        {% set action = 'Action: ' + cell_info.action %}
+        {% set tooltip_info = action + ' - ' + cell_info.comment %}
+    {% elif cell_info.action %}
+        {% set tooltip_info = cell_info.action %}
+    {% elif cell_info.comment %}
+        {% set tooltip_info = cell_info.comment %}
+    {% else %}
+        {% set tooltip_info = None %}
     {% endif %}
-    <span class="fw-normal fs-6">{{st}}</span>
+    <td>
+        <span class="fw-light {{ text_colour }}">
+            {{ status }}
+        </span>
+        {% if tooltip_info %}
+            <i class="bi bi-info-circle"
+                data-bs-toggle="tooltip" data-bs-placement="top"
+                data-bs-title="{{ tooltip_info }}"></i>
+        {% endif %}
+    </td>
 {% endmacro %}
 
-{% macro render_pvl(pvl)  %}
-    {% set pvl_tag = pvl | get_pvl_tag %}
-    <span class="badge bg-{{pvl_tag.severity}} fw-normal">{{pvl_tag.label}}</span>
-{% endmacro %}
-
-{% macro render_mrsa(amr)  %}
+{% macro mrsa_renderer(amr)  %}
     {% set has_meca = amr | has_arg("mecA") %}
+    <td>
     {% if has_meca %}
         <span class="bade bg-danger fw-normal text-light fs-6">MRSA</span>
     {% endif %}
+    </td>
 {% endmacro %}
 
-{% macro render_tags(tag_info)  %}
+{% macro mlst_renderer(cell_info) %}
+    {% if cell_info.data == None %}
+        {% set mlst_st="-" %}
+    {% else %}
+        {% set mlst_st=cell_info.data %}
+    {% endif %}
+    <td>
+        <span class="fw-normal fs-6">{{mlst_st}}</span>
+    </td>
+{% endmacro %}
+
+{% macro pvl_renderer(pvl) %}
+    {% set pvl_tag = pvl | get_pvl_tag %}
+    <td>
+        <span class="badge bg-{{pvl_tag.severity}} fw-normal">{{pvl_tag.label}}</span>
+    </td>
+{% endmacro %}
+
+{% macro tags_renderer(tag_info) %}
     <td data-search="{% for tag in tag_info %}{{tag.label}} {% endfor %}">
     {% for tag in tag_info %}
         <span class="badge text-bg-{{tag.severity}} p-1 me-1">
@@ -46,14 +80,14 @@
     </td>
 {% endmacro %}
 
-
 {% macro comment_tooltip(comment) %}
 <p class='mb-1'>{{ comment.comment }}</p>
 <p class='mt-0 text-end fst-italic'>- {{ comment.username }}</p>
 <hr>
 {% endmacro %}
 
-{% macro render_comments(comments_obj) %}
+{% macro comments_renderer(cell_info) %}
+    {% set comments_obj = cell_info %}
     <td>
         {% if comments_obj | length %}
             <span class="badge text-bg-primary" data-bs-toggle="tooltip" 
@@ -72,30 +106,28 @@
     </td>
 {% endmacro %}
 
-{% macro render_text(text)  %}
-    <span>{{text}}</span>
+{% macro text_renderer(cell_info) %}
+    <td>{{ cell_info }}</td>
 {% endmacro %}
 
-{% macro format_table_cell(cell_info) %}
-    {% if cell_info.type == 'sample_btn' %}
-        <td>{{ render_sampleId(cell_info.data, "Open") }}</td>
-    {% elif cell_info.type == 'tags' %}
-        {{ render_tags(cell_info.data) }}
-    {% elif cell_info.type == 'list' %}
-        <td>{{ cell_info.data | join(', ') }}</td>
-    {% elif cell_info.type == 'taxonomic_name' %}
-        <td>{{ render_taxonomic_name(cell_info.data) }} </td>
-    {% elif cell_info.type in ['date', 'datetime'] %}
-        <td>{{ cell_info.data | strftime }} </td>
-    {% elif cell_info.type == 'qc' %}
-        <td>{{ render_qc(cell_info.data) }}</td>
-    {% elif cell_info.type == 'comments' %}
-        {{ render_comments(cell_info.data) }}
-    {% elif cell_info.type == 'mlst' %}
-        {{ render_mlst(cell_info.data) }}
-    {% elif cell_info.type in ['number', 'integer', 'float'] %}
-        <td data-search="{{ cell_info.data }}" data-sort="{{ cell_info.data }}">{{ cell_info.data | fmt_to_human_readable }}</td>
-    {% else %}
-        <td>{{ cell_info.data }}</td>
-    {% endif %}
+{% macro number_renderer(cell_info) %}
+    <td>{{ cell_info | fmt_number }}</td>
+{% endmacro %}
+
+{% macro date_renderer(cell_info) %}
+    <td>{{ cell_info | strftime }}</td>
+{% endmacro %}
+
+{% macro boolean_renderer(cell_info) %}
+    <td>
+        {% if cell_info %}
+            <i class="bi bi-check-lg"></i>
+        {% else %}
+            <i class="bi bi-x"></i>
+        {% endif %}
+    </td>
+{% endmacro %}
+
+{% macro list_renderer(cell_info) %}
+    <td>{{ cell_info | join(', ') }}</td>
 {% endmacro %}

--- a/frontend/bonsai_app/blueprints/groups/templates/cell_fmt_old.html
+++ b/frontend/bonsai_app/blueprints/groups/templates/cell_fmt_old.html
@@ -1,0 +1,101 @@
+{% macro render_sampleId(sample_id, label)  %}
+    <a href={{url_for('samples.sample', sample_id=sample_id)}}>{{label}}</a>
+{% endmacro %}
+
+{% macro render_taxonomic_name(text)  %}
+    <span class="fw-light fst-italic">{{text}}</span>
+{% endmacro %}
+
+{% macro render_qc(text)  %}
+    {% if text == 'passed' %}
+        {% set text_colour = 'text-success' %}
+    {% elif text == 'failed' %} 
+        {% set text_colour = 'text-danger' %}
+    {% else %}
+        {% set text_colour = '' %}
+    {% endif %}
+    <span class="fw-light {{ text_colour }}">{{ text }}</span>
+{% endmacro %}
+
+{% macro render_mlst(st)  %}
+    {% if st == None %}
+        {% set st="-" %}
+    {% endif %}
+    <span class="fw-normal fs-6">{{st}}</span>
+{% endmacro %}
+
+{% macro render_pvl(pvl)  %}
+    {% set pvl_tag = pvl | get_pvl_tag %}
+    <span class="badge bg-{{pvl_tag.severity}} fw-normal">{{pvl_tag.label}}</span>
+{% endmacro %}
+
+{% macro render_mrsa(amr)  %}
+    {% set has_meca = amr | has_arg("mecA") %}
+    {% if has_meca %}
+        <span class="bade bg-danger fw-normal text-light fs-6">MRSA</span>
+    {% endif %}
+{% endmacro %}
+
+{% macro render_tags(tag_info)  %}
+    <td data-search="{% for tag in tag_info %}{{tag.label}} {% endfor %}">
+    {% for tag in tag_info %}
+        <span class="badge text-bg-{{tag.severity}} p-1 me-1">
+            {{tag.label}}
+        </span>
+    {% endfor %}
+    </td>
+{% endmacro %}
+
+
+{% macro comment_tooltip(comment) %}
+<p class='mb-1'>{{ comment.comment }}</p>
+<p class='mt-0 text-end fst-italic'>- {{ comment.username }}</p>
+<hr>
+{% endmacro %}
+
+{% macro render_comments(comments_obj) %}
+    <td>
+        {% if comments_obj | length %}
+            <span class="badge text-bg-primary" data-bs-toggle="tooltip" 
+                  data-bs-placement="top" data-bs-html="true"
+                  data-bs-title="
+                  <div>
+                  {% for comment in comments_obj %}
+                  {% if comment.displayed %}{{ comment_tooltip(comment) }}{% endif %}
+                  {% endfor %}
+                  </div>
+                  ">
+                <i class="bi bi-chat-right"></i>
+                <span>{{ comments_obj | length }}</span>
+            </span>
+        {% endif %}
+    </td>
+{% endmacro %}
+
+{% macro render_text(text)  %}
+    <span>{{text}}</span>
+{% endmacro %}
+
+{% macro format_table_cell(cell_info) %}
+    {% if cell_info.type == 'sample_btn' %}
+        <td>{{ render_sampleId(cell_info.data, "Open") }}</td>
+    {% elif cell_info.type == 'tags' %}
+        {{ render_tags(cell_info.data) }}
+    {% elif cell_info.type == 'list' %}
+        <td>{{ cell_info.data | join(', ') }}</td>
+    {% elif cell_info.type == 'taxonomic_name' %}
+        <td>{{ render_taxonomic_name(cell_info.data) }} </td>
+    {% elif cell_info.type in ['date', 'datetime'] %}
+        <td>{{ cell_info.data | strftime }} </td>
+    {% elif cell_info.type == 'qc' %}
+        <td>{{ cell_info }}
+    {% elif cell_info.type == 'comments' %}
+        {{ render_comments(cell_info.data) }}
+    {% elif cell_info.type == 'mlst' %}
+        {{ render_mlst(cell_info.data) }}
+    {% elif cell_info.type in ['number', 'integer', 'float'] %}
+        <td data-search="{{ cell_info.data }}" data-sort="{{ cell_info.data }}">{{ cell_info.data | fmt_to_human_readable }}</td>
+    {% else %}
+        <td>{{ cell_info.data }}</td>
+    {% endif %}
+{% endmacro %}

--- a/frontend/bonsai_app/blueprints/groups/templates/edit_groups.html
+++ b/frontend/bonsai_app/blueprints/groups/templates/edit_groups.html
@@ -69,57 +69,6 @@
 {% endmacro %}
 
 
-{% macro column_info_form_old(col) %}
-<div class="br-col-info mb-2 bg-light border">
-    <div class="card-body d-flex justify-content-between">
-        <div class="form-check form-switch pe-2">
-            <input class="form-check-input" type="checkbox" role="switch" id="flexSwitchCheckDefault">
-        </div>
-        <span class="pe-2">{{ col.label }}</span>
-        <div class="btn-group pe-4">
-            {{ inputCheckBtn('sortable', 'Sortable', checked=col.sortable) }}
-            {{ inputCheckBtn('searchable', 'Searchable', checked=col.sortable) }}
-            {{ inputCheckBtn('hidden', 'Hidden', checked=col.hidden) }}
-        </div>
-        <div class="fs-4"><i class="bi bi-list"></i></div>
-    </div>
-</div>
-{% endmacro %}
-
-
-{% macro column_info_form_old(col) %}
-<div class="card mb-2 bg-light column-card">
-    <div class="card-body">
-        <button 
-            class="float-end btn-close" aria-label="Remove"
-            onclick="this.parentElement.parentElement.remove()" type="button"></button>
-        <div class="row">
-            <div class="col-auto">
-                {{ inputText(id='col-label', value=col.label, label='Column name') }}
-            </div>
-            <div class="col-auto">
-                {{ inputText(id='col-data-type', value=col.type, label='Data type') }}
-            </div>
-            <div class="col-lg-6">
-                {{ inputText(id='col-data-path', value=col.path, label='JSON Path') }}
-            </div>
-        </div>
-        <div class="row">
-            <div class="col-auto">
-                {{ inputCheck('sortable', 'Sortable', checked=col.sortable) }}
-            </div>
-            <div class="col-auto">
-                {{ inputCheck('searchable', 'Searchable', checked=col.sortable) }}
-            </div>
-            <div class="col-auto">
-                {{ inputCheck('hidden', 'Hidden', checked=col.hidden) }}
-            </div>
-        </div>
-    </div>
-</div>
-{% endmacro %}
-
-
 {% macro create_or_edit_group(group, valid_columns) %}
 {% if group == None %}
     <h2>Create new group</h2>

--- a/frontend/bonsai_app/blueprints/groups/templates/group.html
+++ b/frontend/bonsai_app/blueprints/groups/templates/group.html
@@ -22,7 +22,7 @@
             <thead><tr><th>Samples</th><th>Updated</th></tr></thead>
             <tbody>
                 <tr>
-                    <td id="samples-counter">{{ table_data | length }}</td>
+                    <td id="samples-counter">{{ table_data.rows | length }}</td>
                     <td id="group-modified-timestamp">{{ modified | strftime }}</td></tr>
             </tbody>
         </table>

--- a/frontend/bonsai_app/blueprints/groups/templates/shared.html
+++ b/frontend/bonsai_app/blueprints/groups/templates/shared.html
@@ -1,5 +1,5 @@
 {% from  'sidebar.html' import qc_classification_form_fields  %}
-{% from "cell_fmt.html" import format_table_cell %}
+{% import "cell_fmt.html" as render_funcs %}
 
 {% macro add_to_basket_btn() %}
 <button id="add-to-basket-btn" class="btn btn-sm btn-outline-success" data-test-id="add-to-basket-btn" disabled>
@@ -86,21 +86,52 @@
         <thead>
             <tr>
                 {# build table header #}
-                {% for col in table_data[0] %}
-                    <td>{{ col.label }}</td>
+                {% for column in table_data.columns %}
+                    {% if column.label is not none %}
+                        <td>{{ column.label }}</td>
+                    {% else %}
+                        <td></td>
+                    {% endif %}
                 {% endfor %}
             </th>
         </thead>
         <tbody>
-            {% for row in table_data %}
-                <tr id="{{ row[0].data }}"
-                 {% if test_id is not none %}data-test-id="sample-row-{{ loop.index }}"{% endif %}
-                 >
-                    {% for cell in row %}
-                        {{ format_table_cell(cell) }}
+            {% for row in table_data.rows %}
+                <tr {% if test_id is not none %}data-test-id="sample-row-{{ loop.index }}"{% endif %}>
+                    {% for col_info in table_data.columns %}
+                        {% set cell_data=row[col_info.id] %}
+                        {{ render_funcs[col_info.renderer](cell_data) }}
                     {% endfor %}
                 </tr>
             {% endfor %}
         </tbody>
     </table>
+{% endmacro %}
+
+
+{% macro render_cell(cell_info) %}
+    {% set style = cell_info.style or '' %}
+    {% set tooltip = cell_info.tooltip or '' %}
+    {% set link = cell_info.link %}
+    {% set data = cell_info.data %}
+    {% set macro = cell_info.render_macro %}
+
+    {% if cell_info.type == "list" %}
+        {% set data = data | join(', ') %}
+    {% elif cell_info.type == "number" %}
+        {% set data = data | fmt_number %}
+    {% endif %}
+
+    {% if macro %}
+        {{ render_funcs[macro](cell_info) }}
+    {% else %}
+        <td class="{{ style }}" 
+            {% if tooltip %}
+                data-bs-toggle="tooltip" data-bs-placement="top"
+                data-bs-title="{{ cell_info.tooltip }}">
+            {% endif %}
+        >
+            {{ data }}
+        </td>
+    {% endif %}
 {% endmacro %}

--- a/frontend/bonsai_app/blueprints/groups/views.py
+++ b/frontend/bonsai_app/blueprints/groups/views.py
@@ -213,6 +213,16 @@ def group(group_id: str) -> str:
     bad_qc_actions = [member.value for member in BadSampleQualityAction]
 
     # get columns from api
+    """TODO
+    
+    Create a structured representation of your table data in the Flask view function. Each cell can include:
+
+    value: the raw or display value
+    style: CSS classes or inline styles
+    tooltip: optional tooltip text
+    link: optional URL for anchor tags
+    render_macro: optional macro name to use in Jinja
+    """
     group_columns: list[dict[str, Any]] = []
     for col in (
         get_valid_group_columns(token_obj=token, qc=True) if display_qc else group_info["table_columns"]

--- a/frontend/bonsai_app/blueprints/groups/views.py
+++ b/frontend/bonsai_app/blueprints/groups/views.py
@@ -126,8 +126,8 @@ def edit_groups(group_id: str | None = None):
         entry.name.lower().capitalize().replace("_", " "): entry.value
         for entry in PhenotypeType.__members__.values()
     }
-
     # get valid columns and set used cols as checked
+    valid_cols = get_valid_group_columns(group_id=group_id, token_obj=token)
     all_group_ids = [group["group_id"] for group in all_groups]
     if group_id is not None and group_id in all_group_ids:
         selected_group = next(
@@ -136,9 +136,10 @@ def edit_groups(group_id: str | None = None):
         cols_in_group = selected_group["table_columns"]
     else:
         cols_in_group = []
-    # Parse column definitions and figure out which should be selected
+
     # annotate if column previously have been selected
-    #valid_cols: list[dict[str, str | bool]] = [{"column_id": col, "selected": col in cols_in_group} for col in COLUMN_CONFIGS]
+    for column in valid_cols:
+        column["selected"] = column["id"] in cols_in_group
 
     return render_template(
         "edit_groups.html",
@@ -187,7 +188,10 @@ def group(group_id: str) -> str:
 
     # generate table data
     columns = group_info.get('table_columns', [])
-    columns = list(DEFAULT_COLUMNS) if len(columns) == 0 else columns
+    if len(columns) > 0: 
+        columns = get_valid_group_columns(token, group_id=group_id)
+    else: # get default columns
+        columns = get_valid_group_columns(token)
     table_data = format_tablular_data(samples_info["data"], columns)
 
     # indicate view in title, used for testing

--- a/frontend/bonsai_app/bonsai.py
+++ b/frontend/bonsai_app/bonsai.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 from requests.structures import CaseInsensitiveDict
 
 from .config import settings
-from .models import SampleBasketObject, SubmittedJob
+from .models import SampleBasketObject, SubmittedJob, ApiGetSamplesDetailsInput
 
 LOG = logging.getLogger(__name__)
 
@@ -240,21 +240,23 @@ def remove_samples_from_basket(
 @api_authentication
 def get_samples(
     headers: CaseInsensitiveDict[str],
-    limit: int = 20,
-    skip: int = 0,
+    limit: int | None= None,
+    skip: int | None = None,
     sample_ids: list[str] | None = None,
 ):
-    """Get multipe samples from database."""
+    """Get multipe samples from database.
+    
+    If sample_ids is provided it will return only those samples.
+    """
     # conduct query
-    url = f"{settings.api_internal_url}/samples/"
+    url = f"{settings.api_internal_url}/samples/summary"
     # get limit, offeset and skip values
-    params: dict[str, int | list[str]] = {"limit": limit, "skip": skip}
     if sample_ids is not None:
         # sanity check list
         if len(sample_ids) == 0:
             raise ValueError("sample_ids list cant be empty!")
-        params["sid"] = sample_ids
-    resp = requests_get(url, headers=headers, params=params)
+    data = ApiGetSamplesDetailsInput.model_validate({"limit": limit, "skip": skip, "sid": sample_ids})
+    resp = requests_post(url, headers=headers, json=data.model_dump())
 
     try:
         resp.raise_for_status()

--- a/frontend/bonsai_app/models.py
+++ b/frontend/bonsai_app/models.py
@@ -16,6 +16,16 @@ class RWModel(BaseModel):  # pylint: disable=too-few-public-methods
     )
 
 
+class ApiGetSamplesDetailsInput(BaseModel):
+    """Input parameters for getting sample details."""
+
+    limit: int | None = None
+    skip: int | None = None
+    prediction_result: bool = True
+    qc_metrics: bool = False
+    sid: list[str] | None = None
+
+
 class SampleBasketObject(RWModel):  # pylint: disable=too-few-public-methods
     """Contaner for sample baskt content."""
 

--- a/frontend/bonsai_app/models.py
+++ b/frontend/bonsai_app/models.py
@@ -1,7 +1,7 @@
 """Data modules shared by the application."""
 
 from enum import Enum
-from typing import List
+from typing import Any, List
 
 from pydantic import BaseModel, ConfigDict
 
@@ -24,6 +24,24 @@ class ApiGetSamplesDetailsInput(BaseModel):
     prediction_result: bool = True
     qc_metrics: bool = False
     sid: list[str] | None = None
+
+
+class TableColumn(BaseModel):
+    """Data structure for a cell in tabular data."""
+
+    id: str
+    label: str
+    type: str = "string"
+    renderer: str = "text_renderer"
+
+
+TableCell = dict[str, Any]
+
+class TableData(BaseModel):
+    """Data structure for tabular data."""
+
+    columns: list[TableColumn]
+    rows: list[TableCell]
 
 
 class SampleBasketObject(RWModel):  # pylint: disable=too-few-public-methods

--- a/frontend/web/js/api.ts
+++ b/frontend/web/js/api.ts
@@ -137,8 +137,11 @@ export class ApiService {
   };
 
   getSamplesDetails = async (query: ApiGetSamplesDetailsInput) => {
-    const url = `/samples/?${objectToQueryParams(query)}`;
-    return this.http.request<ApiSampleDetailsResponse>(url);
+    return this.http.request<ApiSampleDetailsResponse>(`/samples/summary`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(query),
+    });
   };
 
   deleteSamples = async (sampleIds: string[]) => {

--- a/frontend/web/js/components/sample-basket.ts
+++ b/frontend/web/js/components/sample-basket.ts
@@ -41,6 +41,7 @@ export class BasketComponent extends HTMLElement {
         skip: 0,
       };
       const data = await this.getSamplesDetails(query);
+      // create sample cards for each sample in the basket
       data.data.forEach((sample: SamplesDetails) => {
         const item = document.createElement("div");
         item.className = "card mb-2 rounded-1 p-0 sample_in_basket";


### PR DESCRIPTION
This PR adds a toolip to the QC status column that displays the reason why a sample was rejected.

This also changes,
- how columns are associated with the group object in the database to make it more robust
- how data is rendered in the sample table to separate data transformation and rendering
- added `schema version` and migration functions to the group object to make it easier add new functionality in the future