### PR TITLE
Add show selected samples button to sample table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- Added button for showing only selected rows in the sample table
 - Split `BONSAI_API_URL` to two URLs, one for internal frontend-api communication and one for external browser to api communication.
 - Added sequencing run id to sample page
 

--- a/frontend/web/js/bonsai.ts
+++ b/frontend/web/js/bonsai.ts
@@ -29,7 +29,10 @@ const sampleTableConfig = {
   select: true,
   layout: {
     top1Start: {
-      buttons: ["selectAll", "selectNone", "excel"],
+      buttons: ["selectAll", "selectNone", "showSelected"],
+    },
+    top1End: {
+      buttons: ["copy", "csv", "excel"]
     },
     top2Start: "searchBuilder",
   },


### PR DESCRIPTION
This PR adds a button that shows only selected rows to the sample tables in Bonsai. This will help the user to filter the sample table after finding similar samples.
<img width="527" height="375" alt="bild" src="https://github.com/user-attachments/assets/e600083d-ddc1-4fd0-b526-8d02ded45f18" />

close #317 