### PR TITLE
Add basic startup message to the minhash service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- Added basic startup banner to the minhash service.
+- Added support for storing sourmash index in RocksDB format.
 - Added tags that warns the user if a sample might be contaminated. Thresholds are read from `thresholds.toml`file.
 - Added button for showing only selected rows in the sample table
 - Split `BONSAI_API_URL` to two URLs, one for internal frontend-api communication and one for external browser to api communication.
@@ -27,6 +29,7 @@
 
 ### Changed
 
+- Minhash service tasks are now executed through a dispatch function (`minhash_service/tasks/dispatch.py`)
 - Display rejection reason and comments on mouse over in sample table
 - Updated default columns in sample table
 - TbProfiler and SV variants result  tables in the detailed variants view are now sortable and searchable.

--- a/minhash_service/minhash_service/cli/main.py
+++ b/minhash_service/minhash_service/cli/main.py
@@ -63,7 +63,7 @@ def run_cron_scheduler():
     cron = CronScheduler(connection=redis, logging_level=cnf.log_level)
 
     # setup periodic tasks
-    if cnf.periodic_integrity_check.endabled:
+    if cnf.periodic_integrity_check.enabled:
         cron_string = cnf.periodic_integrity_check.cron
         cron.register(
             dispatch_job,
@@ -73,7 +73,7 @@ def run_cron_scheduler():
         )
         log.info("Scheduling periodic integrity check: %s", cron_string)
 
-    if cnf.cleanup_removed_files.endabled:
+    if cnf.cleanup_removed_files.enabled:
         cron_string = cnf.cleanup_removed_files.cron
         cron.register(
             dispatch_job,

--- a/minhash_service/minhash_service/cli/main.py
+++ b/minhash_service/minhash_service/cli/main.py
@@ -20,6 +20,8 @@ from minhash_service.integrity.report_model import InitiatorType
 from minhash_service.tasks import dispatch_job
 from minhash_service.tasks.dispatch import SimpleWhitelistWorker
 
+from .utils import format_startup_banner
+
 
 def _setup_logging(settings: Settings) -> logging.Logger:
     configure_logging(settings)
@@ -38,6 +40,7 @@ def main():
 def run_minhash_worker():
     """Run the RQ worker."""
     log = _setup_logging(cnf)
+    log.info("\n%s", format_startup_banner(cnf, mode="worker"))
 
     # Create mongo connection at startup
     log.info("Setup mongodb connection: %s:%s", cnf.mongodb.host, cnf.mongodb.port)
@@ -58,6 +61,8 @@ def run_minhash_worker():
 def run_cron_scheduler():
     """Run the RQ worker."""
     log = _setup_logging(cnf)
+    log.info("\n%s", format_startup_banner(cnf, mode="scheduler"))
+
     # setup redis connection
     redis = Redis(host=cnf.redis.host, port=cnf.redis.port)
     cron = CronScheduler(connection=redis, logging_level=cnf.log_level)

--- a/minhash_service/minhash_service/cli/utils.py
+++ b/minhash_service/minhash_service/cli/utils.py
@@ -1,0 +1,82 @@
+"""Shared command line utilities."""
+
+from typing import Literal
+
+from minhash_service.core.config import Settings
+
+
+def format_startup_banner(settings: Settings, mode: Literal["worker", "scheduler"]) -> str:
+    """Return a startup banner describing sw configuration."""
+    s = settings
+
+    # Notification status
+    notif_configured = bool(s.notification.api_url)
+    notif_level = s.notification.integrity_report_level.value
+    recip_count = len(s.notification.recipient)
+
+    # Periodic tasks
+    integ_enabled = getattr(s.periodic_integrity_check, "endabled", False)
+    integ_cron = s.periodic_integrity_check.cron
+    integ_queue = s.periodic_integrity_check.queue
+
+    cleanup_enabled = getattr(s.cleanup_removed_files, "endabled", False)
+    cleanup_cron = s.cleanup_removed_files.cron
+    cleanup_queue = s.cleanup_removed_files.queue
+
+    # Build banner
+    title = f"Minhash Service — {mode.upper()}"
+    title_bar = "─" * len(title)
+
+    lines: list[str] = [
+        f"{title}\n{title_bar}",
+        f"Log level: {s.log_level.value}",
+        "",
+        "Storage & Signatures",
+        f"  • signature_dir: {s.signature_dir}",
+        f"  • trash_dir:     {s.trash_dir}",
+        f"  • index_format:  {s.index_format.value}",
+        f"  • kmer_size:     {s.kmer_size if s.kmer_size is not None else 'auto'}",
+        "",
+        "MongoDB",
+        f"  • host:        {s.mongodb.host}",
+        f"  • port:        {s.mongodb.port}",
+        f"  • db:          {s.mongodb.database}",
+        f"  • signatures:  {s.mongodb.signature_collection}",
+        f"  • reports:     {s.mongodb.report_collection}",
+        f"  • audit trail: {s.mongodb.audit_trail_collection}",
+        "",
+        "Redis",
+        f"  • host: {s.redis.host}",
+        f"  • port: {s.redis.port}",
+        f"  • default queue: {s.redis.queue}",
+        "",
+        "Notifications",
+        f"  • configured: {'YES' if notif_configured else 'NO'}",
+        f"  • level:      {notif_level}",
+        f"  • recipients: {recip_count}",
+    ]
+
+    if mode == "worker":
+        lines += [
+            "",
+            "Worker",
+            f"  • RQ queues: [{s.redis.queue}]",
+            "  • Actions:",
+            "      − Initialize MongoDB indexes",
+            "      − Start RQ worker",
+        ]
+    else:
+        lines += [
+            "",
+            "Scheduler (periodic tasks)",
+            f"  • integrity_check: {'ENABLED' if integ_enabled else 'DISABLED'}"
+            + (f" → {integ_cron} (queue='{integ_queue}')" if integ_enabled else ""),
+            f"  • cleanup_removed_files: {'ENABLED' if cleanup_enabled else 'DISABLED'}"
+            + (f" → {cleanup_cron} (queue='{cleanup_queue}')" if cleanup_enabled else ""),
+            "",
+            "  • Actions:",
+            "      − Register enabled cron jobs",
+            "      − Start RQ CronScheduler",
+        ]
+
+    return "\n".join(lines)

--- a/minhash_service/minhash_service/core/config.py
+++ b/minhash_service/minhash_service/core/config.py
@@ -53,8 +53,9 @@ class MongodbConfig(BaseSettings):
     host: str = "mongodb"
     port: PositiveInt = 27017
     database: str = "minhash_db"
-    collection: str = "signatures"
-    log_collection: str = "logs"
+    signature_collection: str = "signatures"
+    report_collection: str = "report"
+    audit_trail_collection: str = "audit_trail"
 
 
 class RedisConfig(BaseSettings):

--- a/minhash_service/minhash_service/core/config.py
+++ b/minhash_service/minhash_service/core/config.py
@@ -140,14 +140,10 @@ class Settings(BaseSettings):
     @model_validator(mode="after")
     def validate_report_service_config(self):
         """Ensure that API url is set when errors should be reported."""
-        should_notify_failed_report = any(
-            [
-                self.notification.integrity_report_level == IntegrityReportLevel.ERROR,
-                self.notification.integrity_report_level
-                == IntegrityReportLevel.WARNING,
-            ]
-        )
-        if should_notify_failed_report and not self.is_notification_configured:
+        requires_notifier = self.notification.integrity_report_level in {
+            IntegrityReportLevel.ERROR, IntegrityReportLevel.WARNING
+        }
+        if requires_notifier and not self.is_notification_configured:
             raise ValidationError("Notification serivce URL must be configures.")
         return self
 
@@ -155,9 +151,9 @@ class Settings(BaseSettings):
     @property
     def is_notification_configured(self) -> bool:
         """Return true URL to notificaiton API has been configured."""
-        return self.notification.api_url is None
+        return self.notification.api_url is not None
 
-    def build_logging_conffig(self) -> dict[str, Any]:
+    def build_logging_config(self) -> dict[str, Any]:
         """Build logging configuration dictionary."""
         log_config = deepcopy(LOG_CONFIG)
         # update log levels
@@ -193,7 +189,7 @@ LOG_CONFIG: dict[str, Any] = {
 
 def configure_logging(settings: Settings) -> None:
     """Configure logging from settings."""
-    logging_config.dictConfig(settings.build_logging_conffig())
+    logging_config.dictConfig(settings.build_logging_config())
 
 
 cnf = Settings()

--- a/minhash_service/minhash_service/core/config.py
+++ b/minhash_service/minhash_service/core/config.py
@@ -77,7 +77,7 @@ class NotificationConfig(BaseSettings):
 class BasePeriodicTaskConfig(BaseSettings):
     """Generic configuration for periodic integrity check task."""
 
-    endabled: bool = True  # enable/disable background task processing
+    enabled: bool = True  # enable/disable background task processing
     cron: str = "0 12 * * SAT"  # cron schedule for periodic tasks
     queue: str = "minhash"  # redis queue name for periodic tasks
 

--- a/minhash_service/minhash_service/core/factories.py
+++ b/minhash_service/minhash_service/core/factories.py
@@ -1,5 +1,6 @@
 """Factory functions related to data stores and repos."""
 
+from minhash_service.core.config import cnf
 from minhash_service.audit import AuditTrailRepository
 from minhash_service.db import MongoDB
 from minhash_service.integrity.report_repository import IntegrityReportRepository
@@ -8,14 +9,14 @@ from minhash_service.signatures.repository import SignatureRepository
 
 def create_signature_repo() -> SignatureRepository:
     """Get signature repository."""
-    collection = MongoDB.get_db().get_collection("signatures")
+    collection = MongoDB.get_db().get_collection(cnf.mongodb.signature_collection)
     repo = SignatureRepository(collection=collection)
     return repo
 
 
 def create_audit_trail_repo() -> AuditTrailRepository:
     """Get audit trail store."""
-    collection = MongoDB.get_db().get_collection("audit_trail")
+    collection = MongoDB.get_db().get_collection(cnf.mongodb.audit_trail_collection)
     repo = AuditTrailRepository(collection=collection)
     return repo
 
@@ -23,7 +24,7 @@ def create_audit_trail_repo() -> AuditTrailRepository:
 def create_report_repo() -> IntegrityReportRepository:
     """Get integrity report store."""
 
-    collection = MongoDB.get_db().get_collection("reports")
+    collection = MongoDB.get_db().get_collection(cnf.mongodb.report_collection)
     repo = IntegrityReportRepository(collection=collection)
     return repo
 


### PR DESCRIPTION
This PR adds a basic startup message to the *minhash service* that display the current configuration.

Example of the startup message.

```
Minhash Service — SCHEDULER
───────────────────────────
Log level: INFO

Storage & Signatures
  • signature_dir: /data/signature_db
  • trash_dir:     /tmp/minhash_trash_g5i8b09b
  • index_format:  SBT
  • kmer_size:     31

MongoDB
  • host:        mongodb
  • port:        27017
  • db:          minhash_db
  • signatures:  signatures
  • reports:     report
  • audit trail: audit_trail

Redis
  • host: redis
  • port: 6379
  • default queue: minhash

Notifications
  • configured: NO
  • level:      NEVER
  • recipients: 0

Scheduler (periodic tasks)
  • integrity_check: DISABLED
  • cleanup_removed_files: DISABLED

  • Actions:
      − Register enabled cron jobs
      − Start RQ CronScheduler
```