### PR TITLE
Rework how grouping samples are managed internally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- Added a GET /memberships router for querying samples belonging to groups and vice versa.
 - Show groups a sample is a member of in the sample table.
 - Added button for showing only selected rows in the sample table
 
@@ -12,6 +13,7 @@
 
 ### Changed
 
+- Sample collection now keep track of group memberships.
 - An user can now add samples to multiple groups at the same time.
 - Improved seeding of a development Bonsai database with a new `seed_db.py` script.
 - TbProfiler and SV variants result  tables in the detailed variants view are now sortable and searchable.

--- a/api/bonsai_api/crud/group.py
+++ b/api/bonsai_api/crud/group.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Any
 
-from api.bonsai_api.models.memberships import SampleGroupLink
+from bonsai_api.models.memberships import SampleGroupLink
 from api_client.audit_log.client import AuditLogClient
 from api_client.audit_log.models import SourceType, Subject
 from bonsai_api.db import Database

--- a/api/bonsai_api/crud/group.py
+++ b/api/bonsai_api/crud/group.py
@@ -3,22 +3,23 @@
 import logging
 from typing import Any
 
+from api.bonsai_api.models.memberships import SampleGroupLink
 from api_client.audit_log.client import AuditLogClient
 from api_client.audit_log.models import SourceType, Subject
 from bonsai_api.db import Database
 from bonsai_api.models.context import ApiRequestContext
-from bonsai_api.models.group import (GroupInCreate, GroupInfoDatabase,
-                                     SampleSampleGroupMemberships)
+from bonsai_api.models.group import GroupInCreate, GroupInfoDatabase
 from bonsai_api.models.sample import SampleSummary
 from bonsai_api.utils import get_timestamp
 from prp.models.typing import TypingMethod
 from pydantic import ValidationError
-from pymongo import ASCENDING, ReturnDocument, UpdateOne
-from pymongo.errors import BulkWriteError, DuplicateKeyError, PyMongoError
+from pymongo import ASCENDING, ReturnDocument
+from pymongo.errors import DuplicateKeyError, PyMongoError
 
 from .errors import DatabaseOperationError, EntryNotFound
 from .tags import compute_phenotype_tags
-from .utils import audit_event_context
+from .utils import audit_event_context, check_groups_exists
+from .memberships import remove_memberships
 
 LOG = logging.getLogger(__name__)
 
@@ -82,16 +83,6 @@ async def get_groups(
             f"Database error occurred while retrieving groups: {str(pme)}"
         ) from pme
     return groups
-
-
-async def check_group_exists(db: Database, group_id: str, session: Any = None) -> bool:
-    """Check if group with group_id exists in database."""
-    if not group_id:
-        return False
-    doc = await db.sample_group_collection.find_one(
-        {"group_id": group_id}, {"_id": 1}, session=session
-    )
-    return doc is not None
 
 
 def _build_sample_lookup_stages() -> list[dict[str, Any]]:
@@ -258,14 +249,18 @@ async def delete_group(
 
     event_subject = Subject(id=group_id, type=SourceType.USR)
     meta = {"group_id": group_id}
-    with audit_event_context(audit, "delete_group", ctx, event_subject):
+    with audit_event_context(audit, "delete_group", ctx, event_subject, metadata=meta):
         async with db.client.start_session() as session:
             try:
                 txn = await session.start_transaction()
                 async with txn:
-                    existing = await check_group_exists(db, group_id, session=session)
-                    if not existing:
+                    missing = await check_groups_exists(db, [group_id], session=session)
+                    if missing:
                         raise EntryNotFound(group_id)
+
+                    # Remove group from stored memberships
+                    links = [SampleGroupLink(group_ids=[group_id])]
+                    await remove_memberships(db, links=links, session=session)
 
                     # Remove group document
                     group_res = await db.sample_group_collection.delete_one(
@@ -273,15 +268,6 @@ async def delete_group(
                     )
                     if group_res.deleted_count == 0:
                         raise EntryNotFound(group_id)
-
-                    # Remove group from sample membership collection
-                    membership_res = (
-                        await db.sample_group_membership_collection.update_many(
-                            {"$pull": {"groups": {"group_id": group_id}}},
-                            session=session,
-                        )
-                    )
-                    meta.update({"membership_deleted": membership_res.modified_count})
 
                     return group_res.deleted_count
             except PyMongoError as pme:
@@ -327,170 +313,3 @@ async def update_group(
             raise EntryNotFound(group_id)
 
     return GroupInfoDatabase.model_validate(updated)
-
-
-async def update_image(db: Database, image: GroupInCreate) -> GroupInfoDatabase:
-    """Create a new collection document."""
-    # cast input data as the type expected to insert in the database
-    db_obj = await db.sample_group_collection.insert_one(image.model_dump())
-    return db_obj
-
-
-async def add_samples_to_group(
-    db: Database,
-    group_id: str,
-    sample_ids: list[str],
-    ctx: ApiRequestContext,
-    audit: AuditLogClient | None = None,
-) -> None:
-    """Create a new collection document."""
-    if not sample_ids:
-        return
-
-    group_record = await get_group(db, group_id)
-    if not group_record:
-        raise EntryNotFound(group_id)
-
-    # Prepare audit log context
-    event_subject = Subject(id=group_id, type=SourceType.USR)
-    meta = {"sample_ids": sample_ids}
-    with audit_event_context(audit, "add_samples_to_group", ctx, event_subject, meta):
-        async with db.client.start_session() as session:
-            try:
-                txn = await session.start_transaction()
-                async with txn:
-                    # Update group document
-                    await db.sample_group_collection.update_one(
-                        {"group_id": group_id},
-                        {
-                            "$set": {"modified_at": get_timestamp()},
-                            "$addToSet": {
-                                "included_samples": {"$each": sample_ids},
-                            },
-                        },
-                        session=session,
-                    )
-                    # prepare bulk operations to add group membership to samples
-                    ops = []
-                    group_entry = {
-                        "group_id": group_record.group_id,
-                        "display_name": group_record.display_name,
-                    }
-                    for sid in sample_ids:
-                        ops.append(
-                            UpdateOne(
-                                {"sample_id": sid},
-                                {"$addToSet": {"groups": group_entry}},
-                                upsert=True,
-                            )
-                        )
-
-                    if ops:
-                        await db.sample_group_membership_collection.bulk_write(
-                            ops, ordered=False, session=session
-                        )
-            except BulkWriteError as bwe:
-                LOG.error(
-                    "Bulk write error while adding samples to group membership: %s",
-                    bwe.details,
-                )
-                raise DatabaseOperationError(
-                    f"Errors occurred while adding samples to group membership: {bwe.details}"
-                ) from bwe
-            except PyMongoError as pme:
-                LOG.error("MongoDB error while adding samples to group: %s", str(pme))
-                raise DatabaseOperationError(
-                    f"Database error occurred while adding samples to group: {str(pme)}"
-                ) from pme
-
-
-async def remove_samples_from_group(
-    db: Database,
-    group_id: str,
-    sample_ids: list[str],
-    ctx: ApiRequestContext,
-    audit: AuditLogClient | None = None,
-) -> None:
-    """Create a new collection document."""
-    if not sample_ids:
-        return
-
-    existing = await check_group_exists(db, group_id)
-    if not existing:
-        raise EntryNotFound(group_id)
-
-    event_subject = Subject(id=group_id, type=SourceType.USR)
-    meta = {"sample_ids": sample_ids}
-    with audit_event_context(audit, "add_samples_to_group", ctx, event_subject, meta):
-        async with db.client.start_session() as session:
-            try:
-                txn = await session.start_transaction()
-                async with txn:
-                    await db.sample_group_collection.update_one(
-                        {"group_id": group_id},
-                        {
-                            "$set": {"modified_at": get_timestamp()},
-                            "$pull": {
-                                "included_samples": {"$in": sample_ids},
-                            },
-                        },
-                        session=session,
-                    )
-                # prepare to remove group from sample membership collection
-                ops = []
-                for sid in sample_ids:
-                    ops.append(
-                        UpdateOne(
-                            {"sample_id": sid},
-                            {"$pull": {"groups": {"group_id": group_id}}},
-                        )
-                    )
-                if ops:
-                    await db.sample_group_membership_collection.bulk_write(ops)
-            except BulkWriteError as bwe:
-                LOG.error(
-                    "Bulk write error while removing samples from group membership: %s",
-                    bwe.details,
-                )
-                raise DatabaseOperationError(
-                    f"Errors occurred while removing samples from group membership: {bwe.details}"
-                ) from bwe
-            except PyMongoError as pme:
-                LOG.error(
-                    "MongoDB error while removing samples from group: %s", str(pme)
-                )
-                raise DatabaseOperationError(
-                    f"Database error occurred while removing samples from group: {str(pme)}"
-                ) from pme
-
-
-async def get_samples_group_membership(
-    db: Database, sample_ids: list[str]
-) -> SampleSampleGroupMemberships:
-    """Get group membership for a list of sample IDs.
-
-    Returns a mapping of sample_id to list of group_ids the sample belongs to.
-    """
-    if not sample_ids:
-        return {}
-
-    pipeline = [
-        {"$match": {"sample_id": {"$in": sample_ids}}},
-        {"$unwind": {"path": "$groups", "preserveNullAndEmptyArrays": True}},
-        {
-            "$group": {
-                "_id": "$sample_id",
-                "group_ids": {"$addToSet": "$groups.group_id"},
-            }
-        },
-        {"$project": {"_id": 0, "sample_id": "$_id", "group_ids": 1}},
-    ]
-
-    cursor = await db.sample_group_membership_collection.aggregate(pipeline)
-    result: dict[str, list[str]] = {}
-    async for doc in cursor:
-        result[doc["sample_id"]] = doc.get("group_ids", []) or []
-    # ensure requested ids are present in ouput
-    for sid in sample_ids:
-        result.setdefault(sid, [])
-    return result

--- a/api/bonsai_api/crud/group.py
+++ b/api/bonsai_api/crud/group.py
@@ -18,7 +18,7 @@ from pymongo.errors import DuplicateKeyError, PyMongoError
 
 from .errors import DatabaseOperationError, EntryNotFound
 from .tags import compute_phenotype_tags
-from .utils import audit_event_context, check_groups_exists
+from .utils import audit_event_context, check_groups_exists, managed_transaction
 from .memberships import remove_memberships
 
 LOG = logging.getLogger(__name__)
@@ -250,26 +250,24 @@ async def delete_group(
     event_subject = Subject(id=group_id, type=SourceType.USR)
     meta = {"group_id": group_id}
     with audit_event_context(audit, "delete_group", ctx, event_subject, metadata=meta):
-        async with db.client.start_session() as session:
+        async with managed_transaction(db.client) as session:
             try:
-                txn = await session.start_transaction()
-                async with txn:
-                    missing = await check_groups_exists(db, [group_id], session=session)
-                    if missing:
-                        raise EntryNotFound(group_id)
+                missing = await check_groups_exists(db, [group_id], session=session)
+                if missing:
+                    raise EntryNotFound(group_id)
 
-                    # Remove group from stored memberships
-                    links = [SampleGroupLink(group_ids=[group_id])]
-                    await remove_memberships(db, links=links, session=session)
+                # Remove group from stored memberships
+                links = [SampleGroupLink(group_ids=[group_id])]
+                await remove_memberships(db, links=links, session=session)
 
-                    # Remove group document
-                    group_res = await db.sample_group_collection.delete_one(
-                        {"group_id": group_id}, session=session
-                    )
-                    if group_res.deleted_count == 0:
-                        raise EntryNotFound(group_id)
+                # Remove group document
+                group_res = await db.sample_group_collection.delete_one(
+                    {"group_id": group_id}, session=session
+                )
+                if group_res.deleted_count == 0:
+                    raise EntryNotFound(group_id)
 
-                    return group_res.deleted_count
+                return group_res.deleted_count
             except PyMongoError as pme:
                 LOG.error("MongoDB error while deleting group: %s", str(pme))
                 raise DatabaseOperationError(

--- a/api/bonsai_api/crud/group.py
+++ b/api/bonsai_api/crud/group.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Any
 
-from bonsai_api.models.memberships import SampleGroupLink
+from bonsai_api.models.memberships import MembershipEdge
 from api_client.audit_log.client import AuditLogClient
 from api_client.audit_log.models import SourceType, Subject
 from bonsai_api.db import Database
@@ -19,7 +19,7 @@ from pymongo.errors import DuplicateKeyError, PyMongoError
 from .errors import DatabaseOperationError, EntryNotFound
 from .tags import compute_phenotype_tags
 from .utils import audit_event_context, check_groups_exists, managed_transaction
-from .memberships import remove_memberships
+from .memberships import remove_memberships, get_samples_by_group_ids
 
 LOG = logging.getLogger(__name__)
 
@@ -184,13 +184,6 @@ async def get_group(
 
         cursor = await db.sample_group_collection.aggregate(pipeline, session=session)
         async for group in cursor:
-            if lookup_samples and group.get("included_samples"):
-                try:
-                    _enrich_group_samples(group)
-                except (ValidationError, ValueError) as exc:
-                    LOG.warning(
-                        "Failed to enrich samples for %s: %s. Skipping.", group_id, exc
-                    )
             return group_document_to_db_object(group)
         # Raise error if no group was found
         raise EntryNotFound(group_id)
@@ -257,8 +250,8 @@ async def delete_group(
                     raise EntryNotFound(group_id)
 
                 # Remove group from stored memberships
-                links = [SampleGroupLink(group_ids=[group_id])]
-                await remove_memberships(db, links=links, session=session)
+                edges = await get_samples_by_group_ids([group_id], db=db, session=session)
+                await remove_memberships(edges, db=db, session=session)
 
                 # Remove group document
                 group_res = await db.sample_group_collection.delete_one(

--- a/api/bonsai_api/crud/memberships.py
+++ b/api/bonsai_api/crud/memberships.py
@@ -1,5 +1,6 @@
 """Manage relationships between samples and groups."""
 
+from collections import defaultdict
 import logging
 from pymongo import UpdateOne
 from pymongo.errors import BulkWriteError, PyMongoError
@@ -17,6 +18,23 @@ from .errors import DatabaseOperationError, EntryNotFound
 LOG = logging.getLogger(__name__)
 
 
+def _transpose_samples_per_group(links: list[SampleGroupLink]) -> list[GroupSampleLink]:
+    """Transpose SampleGroupLinks to GroupSampleLink.
+    
+    Efficiently transpose {sid: list[gid]} to {gid: list[sid]}."""
+    bucket = defaultdict(set)
+    for link in links:
+        sid = link.sample_id
+        for gid in link.group_ids:
+            bucket[gid].add(sid)
+
+    # cast as determenistic GroupSampleLinks
+    upd_links = []
+    for gid, sids in sorted(bucket.items(), key=lambda x: x[0]):
+        upd_links.append(GroupSampleLink(group_id=gid, sample_ids=sorted(sids)))
+    return upd_links
+
+
 async def add_memberships(
     db: Database, links: list[SampleGroupLink],
     *, session: ClientSession | None = None
@@ -27,28 +45,33 @@ async def add_memberships(
 
     async def _do_work(db: Database, links: list[SampleGroupLink], session: ClientSession) -> None:
         # verify that group exists
-        gids = {gid for lnk in links for gid in lnk.group_ids}
-        missing_gids = check_groups_exists(db, gids, session)
+        gids = list({gid for lnk in links for gid in lnk.group_ids})
+        missing_gids = await check_groups_exists(db, gids, session)
         if missing_gids:
             # Abort the transaction if non-existant group was provided
             raise EntryNotFound(f"Unkown group_id(s): {sorted(missing_gids)}")
 
         # update modified timestamp in document
-        await db.sample_group_collection.update_many(
-            {"group_id": {"$in": list(gids)}},
-            {"$set": {"modified_at": get_timestamp()}},
-            session=session,
-        )
+        gs_links = _transpose_samples_per_group(links)
+        gr_ops = []
+        for lnk in gs_links:
+            gr_ops.append(UpdateOne(
+                {"group_id": lnk.group_id},
+                {"$set": {"modified_at": get_timestamp()}, "$inc": { "sample_count": len(lnk.sample_ids) }},
+            ))
+        if gr_ops:
+            await db.sample_group_collection.bulk_write(gr_ops, ordered=False, session=session)
+
         # prepare bulk operations to add group membership to samples
-        ops = []
+        smp_ops = []
         for lnk in links:
-            ops.append(UpdateOne(
+            smp_ops.append(UpdateOne(
                 {"sample_id": lnk.sample_id},
                 {"$addToSet": {"groups": {"$each": lnk.group_ids}}},
                 upsert=False
             ))
-        if ops:
-            await db.sample_collection.bulk_write(ops, ordered=False, session=session)
+        if smp_ops:
+            await db.sample_collection.bulk_write(smp_ops, ordered=False, session=session)
 
     try:
         async with managed_transaction(db.client, session) as sess:
@@ -81,17 +104,21 @@ async def remove_memberships(
     async def _do_work(db: Database, links: list[SampleGroupLink], session: ClientSession) -> None:
         # verify that group exists
         gids = {gid for lnk in links for gid in lnk.group_ids}
-        missing_gids = check_groups_exists(db, gids, session)
+        missing_gids = await check_groups_exists(db, gids, session)
         if missing_gids:
             # Abort the transaction if non-existant group was provided
             raise EntryNotFound(f"Unkown group_id(s): {sorted(missing_gids)}")
         
-        # Update modified timestamp in group object
-        await db.sample_group_collection.update_many(
-            {"group_id": {"$in": list(gids)}},
-            {"$set": {"modified_at": get_timestamp()}},
-            session=session,
-        )
+        # update modified timestamp in document
+        gs_links = _transpose_samples_per_group(links)
+        gr_ops = []
+        for lnk in gs_links:
+            gr_ops.append(UpdateOne(
+                {"group_id": lnk.group_id}, 
+                {"$set": {"modified_at": get_timestamp()}, "$dec": { "sample_count": -len(lnk.sample_ids) }},
+            ))
+        if gr_ops:
+            await db.sample_group_collection.bulk_write(gr_ops, ordered=False, session=session)
 
         # Prepare bulk operations to add group membership to samples
         ops = []
@@ -152,7 +179,7 @@ async def get_samples_by_group_ids(
     if not group_ids:
         return []
 
-    missing_gids = check_groups_exists(db, group_ids)
+    missing_gids = await check_groups_exists(db, group_ids)
     if missing_gids:
         # Abort the transaction if non-existant group was provided
         raise EntryNotFound(f"Unkown group_id(s): {sorted(missing_gids)}")

--- a/api/bonsai_api/crud/memberships.py
+++ b/api/bonsai_api/crud/memberships.py
@@ -187,7 +187,7 @@ async def get_samples_by_group_ids(
     pipeline = [
         {"$match": {"groups": {"$in": group_ids}}},
         {"$project": {"_id": 0, "sample_id": 1, "groups": 1}},
-        {"$unwind": "groups"},
+        {"$unwind": "$groups"},
         {"$match": {"groups": {"$in": group_ids}}},
         {"$group": {"_id": "$groups", "sample_ids": {"$addToSet": "$sample_id"}}},
         {"$project": {"_id": 0, "group_id": "$_id", "sample_ids": 1}},

--- a/api/bonsai_api/crud/memberships.py
+++ b/api/bonsai_api/crud/memberships.py
@@ -148,9 +148,9 @@ async def _mutate_memberships(
     await _check_exists(db, sample_ids, group_ids, session=session)
 
     # 2. Fetch existing memberships for the samples implicated
-    sid_edges = await get_groups_by_sample_ids(db, sample_ids, session=session)
+    sid_edges = await get_groups_by_sample_ids(sample_ids, db=db, session=session)
     present: dict[str, set[str]] = {
-        sid: set(gids) for sid, gids in groupby(sid_edges, lambda e: e.sample_id)
+        sid: {e.group_id for e in edges} for sid, edges in groupby(sid_edges, lambda e: e.sample_id)
     }
 
     # 3. Compute new edges that shall to be added

--- a/api/bonsai_api/crud/memberships.py
+++ b/api/bonsai_api/crud/memberships.py
@@ -64,7 +64,7 @@ def _compute_delta(
 
     if mode == "add":
         for e in edges:
-            if e.group_id not in present[e.sample_id]:
+            if e.group_id not in present.get(e.sample_id, set()):
                 per_sample[e.sample_id].add(e.group_id)
         for _, gids in per_sample.items():
             for gid in gids:
@@ -72,7 +72,7 @@ def _compute_delta(
 
     else:  # remove
         for e in edges:
-            if e.group_id in present[e.sample_id]:
+            if e.group_id in present.get(e.sample_id, set()):
                 per_sample[e.sample_id].add(e.group_id)
         for _, gids in per_sample.items():
             for gid in gids:

--- a/api/bonsai_api/crud/memberships.py
+++ b/api/bonsai_api/crud/memberships.py
@@ -234,7 +234,7 @@ async def get_groups_by_sample_ids(
 
     result = []
     async for doc in cursor:
-        for gid in doc["groups"]:
+        for gid in doc.get("groups", []):
             result.append(MembershipEdge(sample_id=doc["sample_id"], group_id=gid))
     # ensure requested ids are present in ouput
     return result

--- a/api/bonsai_api/crud/memberships.py
+++ b/api/bonsai_api/crud/memberships.py
@@ -1,139 +1,206 @@
 """Manage relationships between samples and groups."""
 
-from collections import defaultdict
 import logging
-from pymongo import UpdateOne
-from pymongo.errors import BulkWriteError, PyMongoError
-from pymongo.client_session import ClientSession
+from collections import defaultdict
+from datetime import datetime
+from itertools import groupby
+from typing import Literal
 
-from .utils import check_groups_exists, managed_transaction
 from bonsai_api.db import Database
-
+from bonsai_api.models.memberships import MembershipEdge, MembershipEdges
 from bonsai_api.utils import get_timestamp
-from bonsai_api.models.memberships import GroupSampleLink, SampleGroupLink
+from pymongo import UpdateOne
+from pymongo.client_session import ClientSession
+from pymongo.errors import BulkWriteError, PyMongoError
 
 from .errors import DatabaseOperationError, EntryNotFound
-
+from .utils import check_groups_exists, check_samples_exists, managed_transaction
 
 LOG = logging.getLogger(__name__)
 
 
-def _transpose_samples_per_group(links: list[SampleGroupLink]) -> list[GroupSampleLink]:
-    """Transpose SampleGroupLinks to GroupSampleLink.
-    
-    Efficiently transpose {sid: list[gid]} to {gid: list[sid]}."""
-    bucket = defaultdict(set)
-    for link in links:
-        sid = link.sample_id
-        for gid in link.group_ids:
-            bucket[gid].add(sid)
+ValidModes = Literal["add", "remvoe"]
 
-    # cast as determenistic GroupSampleLinks
-    upd_links = []
-    for gid, sids in sorted(bucket.items(), key=lambda x: x[0]):
-        upd_links.append(GroupSampleLink(group_id=gid, sample_ids=sorted(sids)))
-    return upd_links
+
+def _dedupe_edges(edges: MembershipEdges) -> MembershipEdges:
+    """Remove duplicate edges."""
+    seen: set[tuple[str, str]] = set()
+    out: MembershipEdges = []
+    for edge in edges:
+        key = (edge.sample_id, edge.group_id)
+        if edge.sample_id and edge.group_id and key not in seen:
+            seen.add(key)
+            out.append(edge)
+    return out
+
+
+async def _check_exists(
+    db: Database,
+    sample_ids: list[str],
+    group_ids: list[str],
+    *,
+    session: ClientSession | None,
+) -> None:
+    """Convenience wrapper for checking if samples and groups exists"""
+    missing_groups = await check_groups_exists(db, group_ids, session)  # set[str]
+    if missing_groups:
+        raise EntryNotFound(f"Unknown group_id(s): {sorted(missing_groups)}")
+    missing_samples = await check_samples_exists(db, sample_ids, session)  # set[str]
+    if missing_samples:
+        raise EntryNotFound(f"Unknown sample_id(s): {sorted(missing_samples)}")
+
+
+def _compute_delta(
+    edges: MembershipEdges, present: dict[str, set[str]], mode: ValidModes
+) -> tuple[dict[str, set[str]], dict[str, int]]:
+    """Compute the delta between exising sample-group edges and the desired change.
+
+    Returns:
+      - per-sample group membership to mutate
+      - per-group counter deltas
+    """
+    per_sample: dict[str, set[str]] = defaultdict(set)
+    per_group_delta: dict[str, int] = defaultdict(int)
+
+    if mode == "add":
+        for e in edges:
+            if e.group_id not in present[e.sample_id]:
+                per_sample[e.sample_id].add(e.group_id)
+        for _, gids in per_sample.items():
+            for gid in gids:
+                per_group_delta[gid] += 1
+
+    else:  # remove
+        for e in edges:
+            if e.group_id in present[e.sample_id]:
+                per_sample[e.sample_id].add(e.group_id)
+        for _, gids in per_sample.items():
+            for gid in gids:
+                per_group_delta[gid] -= 1
+    return per_sample, per_group_delta
+
+
+def _build_sample_ops(
+    per_sample: dict[str, set[str]],
+    mode: ValidModes,
+    ts: datetime,
+) -> list[UpdateOne]:
+    ops: list[UpdateOne] = []
+    for sid, gids in per_sample.items():
+        sorted_gids = sorted(gids)
+        if mode == "add":
+            ops.append(
+                UpdateOne(
+                    {"sample_id": sid},
+                    {
+                        "$addToSet": {"groups": {"$each": sorted_gids}},
+                        "$set": {"modified_at": ts},
+                    },
+                    upsert=False,
+                )
+            )
+        else:
+            ops.append(
+                UpdateOne(
+                    {"sample_id": sid},
+                    {
+                        "$pull": {"groups": {"$in": sorted_gids}},
+                        "$set": {"modified_at": ts},
+                    },
+                    upsert=False,
+                )
+            )
+    return ops
+
+
+def _build_group_ops(
+    per_group_delta: dict[str, int],
+    ts: datetime,
+) -> list[UpdateOne]:
+    ops: list[UpdateOne] = []
+    for gid, delta in per_group_delta.items():
+        if delta == 0:
+            continue
+        ops.append(
+            UpdateOne(
+                {"group_id": gid},
+                {"$inc": {"sample_count": delta}, "$set": {"modified_at": ts}},
+                upsert=False,
+            )
+        )
+    return ops
+
+
+async def _mutate_memberships(
+    edges: MembershipEdge, mode: ValidModes, *, db: Database, session: ClientSession
+) -> None:
+    """Generic function for mutating group memberships using a db transaction."""
+    if not edges:
+        return
+
+    edges = _dedupe_edges(edges)
+
+    # Collect ids
+    sample_ids = sorted({e.sample_id for e in edges})
+    group_ids = sorted({e.group_id for e in edges})
+
+    # 1. Validate that groups and samples exists
+    await _check_exists(db, sample_ids, group_ids, session=session)
+
+    # 2. Fetch existing memberships for the samples implicated
+    sid_edges = await get_groups_by_sample_ids(db, sample_ids, session=session)
+    present: dict[str, set[str]] = {
+        sid: set(gids) for sid, gids in groupby(sid_edges, lambda e: e.sample_id)
+    }
+
+    # 3. Compute new edges that shall to be added
+    per_sample, per_group_delta = _compute_delta(edges, present, mode=mode)
+    if not per_sample:  # nothing to do
+        return
+
+    # 4. Build groups to add per sample and per group sample_count increments
+    ts = get_timestamp()
+    smp_ops = _build_sample_ops(per_sample, mode=mode, ts=ts)
+    grp_ops = _build_group_ops(per_group_delta, ts)
+
+    # 5. Bulk update samples and groups
+    if smp_ops:
+        await db.sample_collection.bulk_write(smp_ops, ordered=False, session=session)
+
+    if grp_ops:
+        await db.sample_group_collection.bulk_write(
+            grp_ops, ordered=False, session=session
+        )
 
 
 async def add_memberships(
-    db: Database, links: list[SampleGroupLink],
-    *, session: ClientSession | None = None
+    edges: MembershipEdges, *, db: Database, session: ClientSession | None = None
 ) -> None:
     """Add new group memberships."""
-    if not links:
-        return
-
-    async def _do_work(db: Database, links: list[SampleGroupLink], session: ClientSession) -> None:
-        # verify that group exists
-        gids = list({gid for lnk in links for gid in lnk.group_ids})
-        missing_gids = await check_groups_exists(db, gids, session)
-        if missing_gids:
-            # Abort the transaction if non-existant group was provided
-            raise EntryNotFound(f"Unkown group_id(s): {sorted(missing_gids)}")
-
-        # update modified timestamp in document
-        gs_links = _transpose_samples_per_group(links)
-        gr_ops = []
-        for lnk in gs_links:
-            gr_ops.append(UpdateOne(
-                {"group_id": lnk.group_id},
-                {"$set": {"modified_at": get_timestamp()}, "$inc": { "sample_count": len(lnk.sample_ids) }},
-            ))
-        if gr_ops:
-            await db.sample_group_collection.bulk_write(gr_ops, ordered=False, session=session)
-
-        # prepare bulk operations to add group membership to samples
-        smp_ops = []
-        for lnk in links:
-            smp_ops.append(UpdateOne(
-                {"sample_id": lnk.sample_id},
-                {"$addToSet": {"groups": {"$each": lnk.group_ids}}},
-                upsert=False
-            ))
-        if smp_ops:
-            await db.sample_collection.bulk_write(smp_ops, ordered=False, session=session)
 
     try:
         async with managed_transaction(db.client, session) as sess:
-            await _do_work(db, links, session=sess)
+            await _mutate_memberships(edges, mode="add", db=db, session=sess)
     except BulkWriteError as bwe:
         LOG.error(
-            "Bulk write error while adding samples to group membership: %s",
+            "Bulk write error while adding membership: %s",
             bwe.details,
         )
         raise DatabaseOperationError(
-            f"Errors occurred while adding samples to group membership: {bwe.details}"
+            f"Errors occurred while adding membership: {bwe.details}"
         ) from bwe
     except PyMongoError as pme:
-        LOG.error("MongoDB error while adding samples to group: %s", str(pme))
-        raise DatabaseOperationError(
-            f"Database error occurred while adding samples to group: {str(pme)}"
-        ) from pme
+        LOG.error("MongoDB error while adding memberships: %s", str(pme))
+        raise DatabaseOperationError(f"Database error: {str(pme)}") from pme
 
 
 async def remove_memberships(
-    db: Database,
-    links: list[SampleGroupLink],
-    *,
-    session: ClientSession | None = None
+    edges: MembershipEdges, *, db: Database, session: ClientSession | None = None
 ) -> None:
     """Remove group memberships."""
-    if not links:
-        return
-
-    async def _do_work(db: Database, links: list[SampleGroupLink], session: ClientSession) -> None:
-        # verify that group exists
-        gids = {gid for lnk in links for gid in lnk.group_ids}
-        missing_gids = await check_groups_exists(db, gids, session)
-        if missing_gids:
-            # Abort the transaction if non-existant group was provided
-            raise EntryNotFound(f"Unkown group_id(s): {sorted(missing_gids)}")
-        
-        # update modified timestamp in document
-        gs_links = _transpose_samples_per_group(links)
-        gr_ops = []
-        for lnk in gs_links:
-            gr_ops.append(UpdateOne(
-                {"group_id": lnk.group_id}, 
-                {"$set": {"modified_at": get_timestamp()}, "$dec": { "sample_count": -len(lnk.sample_ids) }},
-            ))
-        if gr_ops:
-            await db.sample_group_collection.bulk_write(gr_ops, ordered=False, session=session)
-
-        # Prepare bulk operations to add group membership to samples
-        ops = []
-        for lnk in links:
-            ops.append(UpdateOne(
-                {"sample_id": lnk.sample_id},
-                {"$pullAll": {"groups": lnk.group_ids}},
-                upsert=False
-            ))
-        if ops:
-            await db.sample_collection.bulk_write(ops, ordered=False, session=session)
-    
     try:
         async with managed_transaction(db.client, session) as sess:
-            return await _do_work(db, links, session=sess)
+            return await _mutate_memberships(edges, mode="remvoe", db=db, session=sess)
     except BulkWriteError as bwe:
         LOG.error(
             "Bulk write error while removing samples from group: %s",
@@ -147,31 +214,35 @@ async def remove_memberships(
         raise DatabaseOperationError(
             f"Database error occurred while removing samples from group: {str(pme)}"
         ) from pme
-        
+
 
 async def get_groups_by_sample_ids(
-    db: Database, sample_ids: list[str]
-) -> list[SampleGroupLink]:
+    sample_ids: list[str], *, db: Database, session: ClientSession | None = None
+) -> MembershipEdges:
     """Get group membership for a list of sample IDs.
 
     Returns a mapping of sample_id to list of group_ids the sample belongs to.
     """
     if not sample_ids:
         return []
-    
+
     cursor = await db.sample_collection.find(
-        {"sample_id": {"$in": sample_ids}}, {"_id": 0, "sample_id": 1, "groups": 1})
+        {"sample_id": {"$in": sample_ids}},
+        {"_id": 0, "sample_id": 1, "groups": 1},
+        session=session,
+    )
 
     result = []
     async for doc in cursor:
-        result.append(SampleGroupLink(sample_id=doc['sample_id'], group_ids=doc['groups']))
+        for gid in doc["groups"]:
+            result.append(MembershipEdge(sample_id=doc["sample_id"], group_id=gid))
     # ensure requested ids are present in ouput
     return result
 
 
 async def get_samples_by_group_ids(
-    db: Database, group_ids: list[str]
-) -> list[GroupSampleLink]:
+    group_ids: list[str], *, db: Database, session: ClientSession | None = None
+) -> MembershipEdges:
     """Get group membership for a list of sample IDs.
 
     Returns a mapping of sample_id to list of group_ids the sample belongs to.
@@ -186,18 +257,15 @@ async def get_samples_by_group_ids(
 
     pipeline = [
         {"$match": {"groups": {"$in": group_ids}}},
-        {"$project": {"_id": 0, "sample_id": 1, "groups": 1}},
-        {"$unwind": "$groups"},
-        {"$match": {"groups": {"$in": group_ids}}},
-        {"$group": {"_id": "$groups", "sample_ids": {"$addToSet": "$sample_id"}}},
-        {"$project": {"_id": 0, "group_id": "$_id", "sample_ids": 1}},
+        {"$project": {"_id": 0, "sample_id": 1, "group_id": "$groups"}},
+        {"$unwind": "$group_id"},
     ]
 
-    cursor = await db.sample_collection.aggregate(pipeline)
+    cursor = await db.sample_collection.aggregate(pipeline, session=session)
 
-    result: list[GroupSampleLink] = []
+    result = []
     async for doc in cursor:
-        result.append(GroupSampleLink.model_validate(doc))
+        result.append(MembershipEdge.model_validate(doc))
 
     # ensure requested ids are present in ouput
     return result

--- a/api/bonsai_api/crud/memberships.py
+++ b/api/bonsai_api/crud/memberships.py
@@ -226,7 +226,7 @@ async def get_groups_by_sample_ids(
     if not sample_ids:
         return []
 
-    cursor = await db.sample_collection.find(
+    cursor = db.sample_collection.find(
         {"sample_id": {"$in": sample_ids}},
         {"_id": 0, "sample_id": 1, "groups": 1},
         session=session,

--- a/api/bonsai_api/crud/memberships.py
+++ b/api/bonsai_api/crud/memberships.py
@@ -1,0 +1,176 @@
+"""Manage relationships between samples and groups."""
+
+import logging
+from pymongo import UpdateOne
+from pymongo.errors import BulkWriteError, PyMongoError
+from pymongo.client_session import ClientSession
+
+from .utils import check_groups_exists, managed_transaction
+from bonsai_api.db import Database
+
+from bonsai_api.utils import get_timestamp
+from bonsai_api.models.memberships import GroupSampleLink, SampleGroupLink
+
+from .errors import DatabaseOperationError, EntryNotFound
+
+
+LOG = logging.getLogger(__name__)
+
+
+async def add_memberships(
+    db: Database, links: list[SampleGroupLink],
+    *, session: ClientSession | None = None
+) -> None:
+    """Add new group memberships."""
+    if not links:
+        return
+
+    async def _do_work(db: Database, links: list[SampleGroupLink], session: ClientSession) -> None:
+        # verify that group exists
+        gids = {gid for lnk in links for gid in lnk.group_ids}
+        missing_gids = check_groups_exists(db, gids, session)
+        if missing_gids:
+            # Abort the transaction if non-existant group was provided
+            raise EntryNotFound(f"Unkown group_id(s): {sorted(missing_gids)}")
+
+        # update modified timestamp in document
+        await db.sample_group_collection.update_many(
+            {"group_id": {"$in": list(gids)}},
+            {"$set": {"modified_at": get_timestamp()}},
+            session=session,
+        )
+        # prepare bulk operations to add group membership to samples
+        ops = []
+        for lnk in links:
+            ops.append(UpdateOne(
+                {"sample_id": lnk.sample_id},
+                {"$addToSet": {"groups": {"$each": lnk.group_ids}}},
+                upsert=False
+            ))
+        if ops:
+            await db.sample_collection.bulk_write(ops, ordered=False, session=session)
+
+    try:
+        async with managed_transaction(db.client, session) as sess:
+            await _do_work(db, links, session=sess)
+    except BulkWriteError as bwe:
+        LOG.error(
+            "Bulk write error while adding samples to group membership: %s",
+            bwe.details,
+        )
+        raise DatabaseOperationError(
+            f"Errors occurred while adding samples to group membership: {bwe.details}"
+        ) from bwe
+    except PyMongoError as pme:
+        LOG.error("MongoDB error while adding samples to group: %s", str(pme))
+        raise DatabaseOperationError(
+            f"Database error occurred while adding samples to group: {str(pme)}"
+        ) from pme
+
+
+async def remove_memberships(
+    db: Database,
+    links: list[SampleGroupLink],
+    *,
+    session: ClientSession | None = None
+) -> None:
+    """Remove group memberships."""
+    if not links:
+        return
+
+    async def _do_work(db: Database, links: list[SampleGroupLink], session: ClientSession) -> None:
+        # verify that group exists
+        gids = {gid for lnk in links for gid in lnk.group_ids}
+        missing_gids = check_groups_exists(db, gids, session)
+        if missing_gids:
+            # Abort the transaction if non-existant group was provided
+            raise EntryNotFound(f"Unkown group_id(s): {sorted(missing_gids)}")
+        
+        # Update modified timestamp in group object
+        await db.sample_group_collection.update_many(
+            {"group_id": {"$in": list(gids)}},
+            {"$set": {"modified_at": get_timestamp()}},
+            session=session,
+        )
+
+        # Prepare bulk operations to add group membership to samples
+        ops = []
+        for lnk in links:
+            ops.append(UpdateOne(
+                {"sample_id": lnk.sample_id},
+                {"$pullAll": {"groups": lnk.group_ids}},
+                upsert=False
+            ))
+        if ops:
+            await db.sample_collection.bulk_write(ops, ordered=False, session=session)
+    
+    try:
+        async with managed_transaction(db.client, session) as sess:
+            return await _do_work(db, links, session=sess)
+    except BulkWriteError as bwe:
+        LOG.error(
+            "Bulk write error while removing samples from group: %s",
+            bwe.details,
+        )
+        raise DatabaseOperationError(
+            f"Errors occurred while adding samples to group membership: {bwe.details}"
+        ) from bwe
+    except PyMongoError as pme:
+        LOG.error("MongoDB error while adding samples to group: %s", str(pme))
+        raise DatabaseOperationError(
+            f"Database error occurred while removing samples from group: {str(pme)}"
+        ) from pme
+        
+
+async def get_groups_by_sample_ids(
+    db: Database, sample_ids: list[str]
+) -> list[SampleGroupLink]:
+    """Get group membership for a list of sample IDs.
+
+    Returns a mapping of sample_id to list of group_ids the sample belongs to.
+    """
+    if not sample_ids:
+        return []
+    
+    cursor = await db.sample_collection.find(
+        {"sample_id": {"$in": sample_ids}}, {"_id": 0, "sample_id": 1, "groups": 1})
+
+    result = []
+    async for doc in cursor:
+        result.append(SampleGroupLink(sample_id=doc['sample_id'], group_ids=doc['groups']))
+    # ensure requested ids are present in ouput
+    return result
+
+
+async def get_samples_by_group_ids(
+    db: Database, group_ids: list[str]
+) -> list[GroupSampleLink]:
+    """Get group membership for a list of sample IDs.
+
+    Returns a mapping of sample_id to list of group_ids the sample belongs to.
+    """
+    if not group_ids:
+        return []
+
+    missing_gids = check_groups_exists(db, group_ids)
+    if missing_gids:
+        # Abort the transaction if non-existant group was provided
+        raise EntryNotFound(f"Unkown group_id(s): {sorted(missing_gids)}")
+
+    pipeline = [
+        {"$match": {"groups": {"$in": group_ids}}},
+        {"$project": {"_id": 0, "sample_id": 1, "groups": 1}},
+        {"$unwind": "groups"},
+        {"$match": {"groups": {"$in": group_ids}}},
+        {"$group": {"_id": "$groups", "sample_ids": {"$addToSet": "$sample_id"}}},
+        {"$project": {"_id": 0, "group_id": "$_id", "sample_ids": 1}},
+    ]
+
+    cursor = await db.sample_collection.aggregate(pipeline)
+
+    result: list[GroupSampleLink] = []
+    async for doc in cursor:
+        result.append(GroupSampleLink.model_validate(doc))
+
+    # ensure requested ids are present in ouput
+    return result

--- a/api/bonsai_api/crud/sample.py
+++ b/api/bonsai_api/crud/sample.py
@@ -217,21 +217,27 @@ async def get_samples_summary(
     if isinstance(include_samples, list) and len(include_samples) > 0:
         pipeline.append({"$match": {"sample_id": {"$in": include_samples}}})
 
-    # Lookup group membership and return a flat array of groups as `in_groups`.
-    pipeline.append(
+    # Lookup group information and return group display name
+    pipeline.extend([
         {
             "$lookup": {
-                "from": db.sample_group_membership_collection.name,
-                "let": {"sample_id": "$sample_id"},
-                "pipeline": [
-                    {"$match": {"$expr": {"$eq": ["$sample_id", "$$sample_id"]}}},
-                    {"$unwind": "$groups"},
-                    {"$replaceRoot": {"newRoot": "$groups"}},
-                ],
-                "as": "in_groups",
+                "from": db.sample_group_collection.name,
+                "localField": "groups",
+                "foreignField": "group_id",
+                "as": "groups_meta",
             }
-        }
-    )
+        },
+        {"$addFields": {
+            "groups_info": {
+                "$map": {
+                    "input": "$groups_meta",
+                    "as": "g",
+                    "in": {"id": "$$g.group_id", "display_name": "$$g.display_name"},
+                }
+            }
+        }},
+        {"$project": {"groups_meta": 0}}
+    ])
 
     # species prediction projection
     # get the first entry of the bracken result
@@ -267,7 +273,7 @@ async def get_samples_summary(
         "sequencing_run": "$sequencing.run_id",
         "qc_status": 1,
         "metadata": 1,
-        "in_groups": "$in_groups",
+        "groups_info": 1,
         "species_prediction": spp_cmd,
         "created_at": 1,
         "profile": "$pipeline.analysis_profile",

--- a/api/bonsai_api/crud/utils.py
+++ b/api/bonsai_api/crud/utils.py
@@ -1,13 +1,21 @@
 """Generic database functions."""
 
-from contextlib import contextmanager
+import logging
+
+from contextlib import asynccontextmanager, contextmanager
 from typing import Any
+from pymongo import AsyncMongoClient
+from pymongo.collection import Collection
+from pymongo.client_session import ClientSession
 
 import bonsai_api
+from bonsai_api.db import Database
 from api_client.audit_log import AuditLogClient
 from api_client.audit_log.models import EventCreate, EventSeverity, Subject
 from bonsai_api.models.context import ApiRequestContext
-from pymongo.collection import Collection
+
+
+LOG = logging.getLogger(__name__)
 
 
 async def get_deprecated_records(
@@ -54,3 +62,37 @@ def audit_event_context(
                 metadata=meta,
             )
             audit.post_event(event)
+
+
+async def check_groups_exists(db: Database, group_ids: list[str], session: Any = None) -> list[str]:
+    """Check if group with group_id exists in database.
+    
+    Return missing group ids.
+    """
+    if not group_ids:
+        return False
+
+    existing = await db.sample_group_collection.find(
+        {"group_id": {"$in": group_ids}}, {"group_id": 1, "_id": 0}, session=session
+    ).to_list(None)
+
+    existing_ids: set[str] = {gr["group_id"] for gr in existing}
+    missing = set(group_ids) - existing_ids
+    if missing:
+        LOG.warning("Did not find groups: %s", missing)
+    return len(missing) == 0
+
+
+@asynccontextmanager
+async def managed_transaction(client: AsyncMongoClient, session: ClientSession | None = None):
+    """Yields a session, 
+
+    It performs open/ close and starting transaction only if needed."""
+    if session is not None:
+        # If a caller provided a session/ transactipn; just yield it.
+        yield session
+        return
+    
+    async with client.start_session() as sess:
+        async with sess.start_transaction():
+            yield sess

--- a/api/bonsai_api/crud/utils.py
+++ b/api/bonsai_api/crud/utils.py
@@ -41,6 +41,7 @@ def audit_event_context(
     subject: Subject,
     metadata: dict[str, Any] | None = None,
 ):
+    """Logg an event to the audit log."""
     exc = None
     try:
         yield
@@ -94,5 +95,6 @@ async def managed_transaction(client: AsyncMongoClient, session: ClientSession |
         return
     
     async with client.start_session() as sess:
-        async with sess.start_transaction():
+        txn = await sess.start_transaction()
+        async with txn:
             yield sess

--- a/api/bonsai_api/crud/utils.py
+++ b/api/bonsai_api/crud/utils.py
@@ -71,7 +71,10 @@ async def check_groups_exists(db: Database, group_ids: list[str], session: Any =
     Return missing group ids.
     """
     if not group_ids:
-        return False
+        return []
+
+    if not isinstance(group_ids, list):
+        raise RuntimeError(f"Invalid input data, expect list[str] but got: {group_ids}")
 
     existing = await db.sample_group_collection.find(
         {"group_id": {"$in": group_ids}}, {"group_id": 1, "_id": 0}, session=session
@@ -81,7 +84,7 @@ async def check_groups_exists(db: Database, group_ids: list[str], session: Any =
     missing = set(group_ids) - existing_ids
     if missing:
         LOG.warning("Did not find groups: %s", missing)
-    return len(missing) == 0
+    return missing
 
 
 @asynccontextmanager

--- a/api/bonsai_api/crud/utils.py
+++ b/api/bonsai_api/crud/utils.py
@@ -87,6 +87,28 @@ async def check_groups_exists(db: Database, group_ids: list[str], session: Any =
     return missing
 
 
+async def check_samples_exists(db: Database, sample_ids: list[str], session: Any = None) -> list[str]:
+    """Check if group with group_id exists in database.
+    
+    Return missing group ids.
+    """
+    if not sample_ids:
+        return []
+
+    if not isinstance(sample_ids, list):
+        raise RuntimeError(f"Invalid input data, expect list[str] but got: {sample_ids}")
+
+    existing = await db.sample_collection.find(
+        {"sample_id": {"$in": sample_ids}}, {"sample_id": 1, "_id": 0}, session=session
+    ).to_list(None)
+
+    existing_ids: set[str] = {gr["sample_id"] for gr in existing}
+    missing = set(sample_ids) - existing_ids
+    if missing:
+        LOG.warning("Did not find samples: %s", missing)
+    return missing
+
+
 @asynccontextmanager
 async def managed_transaction(client: AsyncMongoClient, session: ClientSession | None = None):
     """Yields a session, 

--- a/api/bonsai_api/db/db.py
+++ b/api/bonsai_api/db/db.py
@@ -27,9 +27,6 @@ class MongoDatabase:  # pylint: disable=too-few-public-methods
         # define collection shorthands
         self.db = self.client.get_database(db_name)
         self.sample_group_collection = self.db.get_collection("sample_group")
-        self.sample_group_membership_collection = self.db.get_collection(
-            "sample_group_membership"
-        )
         self.sample_collection = self.db.get_collection("sample")
         self.location_collection = self.db.get_collection("location")
         self.user_collection = self.db.get_collection("user")

--- a/api/bonsai_api/main.py
+++ b/api/bonsai_api/main.py
@@ -6,13 +6,13 @@ from contextlib import asynccontextmanager
 
 from api_client.audit_log import AuditLogClient
 from api_client.notification import NotificationClient
-from bonsai_api.db.db import MongoDatabase, setup_db_connection
+from bonsai_api.db.db import setup_db_connection
 from fastapi import FastAPI
 
 from .config import Settings, settings
 from .extensions.ldap_extension import ldap_connection
 from .internal.middlewares import configure_cors
-from .routers import (auth, cluster, export, groups, jobs, locations,
+from .routers import (auth, cluster, export, groups, jobs, locations, memberships,
                       resources, root, samples, users)
 
 logging_config.dictConfig(
@@ -80,6 +80,7 @@ def create_app(settings: Settings) -> FastAPI:
     app.include_router(samples.router)
     app.include_router(groups.router)
     app.include_router(locations.router)
+    app.include_router(memberships.router)
     app.include_router(cluster.router)
     app.include_router(export.router)
     app.include_router(resources.router)

--- a/api/bonsai_api/models/group.py
+++ b/api/bonsai_api/models/group.py
@@ -284,6 +284,7 @@ class GroupBase(RWModel):  # pylint: disable=too-few-public-methods
     table_columns: list[SampleTableColumnDB] = Field(
         default=[], description="IDs of columns to display."
     )
+    sample_count: int = Field(default=0, ge=0, description="Total number of samples in this group")
 
 
 class GroupInCreate(GroupBase):  # pylint: disable=too-few-public-methods

--- a/api/bonsai_api/models/group.py
+++ b/api/bonsai_api/models/group.py
@@ -52,12 +52,12 @@ VALID_BASE_COLS: list[SampleTableColumnInput] = [
         sortable=True,
     ),
     SampleTableColumnInput(
-        id="in_groups",
-        label="In groups",
-        path="$.in_groups",
+        id="groups_info",
+        label="Groups",
+        path="$.groups_info",
         sortable=False,
         type="custom",
-        renderer="in_groups_renderer",
+        renderer="groups_info_renderer",
     ),
 ]
 
@@ -259,7 +259,7 @@ DEFAULT_COLUMNS: list[str] = [
     "sample_btn",
     "sample_id",
     "sample_name",
-    "in_groups",
+    "groups_info",
     "tags",
     "assay",
     "taxonomic_name",

--- a/api/bonsai_api/models/group.py
+++ b/api/bonsai_api/models/group.py
@@ -1,34 +1,13 @@
 """Routes related to collections of samples."""
 
-from typing import Dict, List, Literal, TypeAlias
+from typing import Literal
 
 from prp.models.phenotype import ElementType
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, Field
 
-from .base import DBModelMixin, ModifiedAtRWModel, ObjectId, RWModel
-from .sample import SampleSummary
+from .base import DBModelMixin, ModifiedAtRWModel, RWModel
 
-FilterParams = List[Dict[str, str | int | float],]
-
-
-class IncludedSamples(RWModel):  # pylint: disable=too-few-public-methods
-    """Object for keeping track of included samples in a group"""
-
-    included_samples: List[str | SampleSummary] = []
-
-    model_config = ConfigDict(json_encoders={ObjectId: str})
-
-
-class UpdateIncludedSamples(IncludedSamples):  # pylint: disable=too-few-public-methods
-    """Object for keeping track of included samples in a group"""
-
-
-class GroupBase(IncludedSamples):  # pylint: disable=too-few-public-methods
-    """Basic specie information."""
-
-    group_id: str = Field(..., min_length=5)
-    display_name: str = Field(..., min_length=1, max_length=45)
-    description: str | None = None
+FilterParams = list[dict[str, str | int | float],]
 
 
 class SampleTableColumnInput(BaseModel):  # pylint: disable=too-few-public-methods
@@ -296,16 +275,23 @@ qc_cols = [*VALID_BASE_COLS, *VALID_QC_COLS]
 SCHEMA_VERSION: str = "1"
 
 
+class GroupBase(RWModel):  # pylint: disable=too-few-public-methods
+    """Basic specie information."""
+
+    group_id: str = Field(..., min_length=5)
+    display_name: str = Field(..., min_length=1, max_length=45)
+    description: str | None = None
+    table_columns: list[SampleTableColumnDB] = Field(
+        default=[], description="IDs of columns to display."
+    )
+
+
 class GroupInCreate(GroupBase):  # pylint: disable=too-few-public-methods
     """Defines expected input format for groups."""
 
     schema_version: str = Field(
         default=SCHEMA_VERSION, description="Version of the group schema."
     )
-    table_columns: list[SampleTableColumnDB] = Field(
-        default=[], description="IDs of columns to display."
-    )
-    # table_columns: list[SampleTableColumnInput] = Field(default=[], description="IDs of columns to display.")
     validated_genes: dict[ElementType, list[str]] | None = {}
 
 

--- a/api/bonsai_api/models/group.py
+++ b/api/bonsai_api/models/group.py
@@ -321,6 +321,3 @@ class GroupInfoOut(GroupBase):  # pylint: disable=too-few-public-methods
     table_columns: list[str] = Field(
         default=[], description="IDs of columns to display."
     )
-
-
-SampleSampleGroupMemberships: TypeAlias = dict[str, list[str]]

--- a/api/bonsai_api/models/memberships.py
+++ b/api/bonsai_api/models/memberships.py
@@ -8,9 +8,6 @@ from pydantic import BaseModel, Field
 from .base import RWModel
 
 
-MembershipsQueryResponse: TypeAlias = dict[str, list[str]]
-
-
 class SampleGroupLink(BaseModel):
     """Keep track of a sample-group relationship."""
 

--- a/api/bonsai_api/models/memberships.py
+++ b/api/bonsai_api/models/memberships.py
@@ -1,0 +1,32 @@
+"""Models related to sample memberships."""
+
+
+from typing import TypeAlias
+
+from pydantic import BaseModel, Field
+
+from .base import RWModel
+
+
+MembershipsQueryResponse: TypeAlias = dict[str, list[str]]
+
+
+class SampleGroupLink(BaseModel):
+    """Keep track of a sample-group relationship."""
+
+    sample_id: str
+    group_ids: list[str]
+
+
+class GroupSampleLink(BaseModel):
+    """Keep track of a sample-group relationship."""
+
+    group_id: str
+    sample_ids: list[str]
+
+
+class SampleMembershipInput(RWModel):  # pylint: disable=too-few-public-methods
+    """Input model for sample group membership."""
+
+    sample_ids: list[str] = Field(..., description="Sample ids")
+    group_ids: list[str] = Field(..., description="Group ids")

--- a/api/bonsai_api/models/memberships.py
+++ b/api/bonsai_api/models/memberships.py
@@ -1,6 +1,5 @@
 """Models related to sample memberships."""
 
-
 from typing import TypeAlias
 
 from pydantic import BaseModel, Field
@@ -8,18 +7,14 @@ from pydantic import BaseModel, Field
 from .base import RWModel
 
 
-class SampleGroupLink(BaseModel):
-    """Keep track of a sample-group relationship."""
+class MembershipEdge(BaseModel):
+    """Describe a relationship between a sample and group."""
 
     sample_id: str
-    group_ids: list[str]
-
-
-class GroupSampleLink(BaseModel):
-    """Keep track of a sample-group relationship."""
-
     group_id: str
-    sample_ids: list[str]
+
+
+MembershipEdges: TypeAlias = list[MembershipEdge]
 
 
 class SampleMembershipInput(RWModel):  # pylint: disable=too-few-public-methods

--- a/api/bonsai_api/models/sample.py
+++ b/api/bonsai_api/models/sample.py
@@ -138,9 +138,3 @@ class MultipleSampleRecordsResponseModel(
     MultipleRecordsResponseModel
 ):  # pylint: disable=too-few-public-methods
     data: list[SampleInDatabase] = []
-
-
-class SampleGroupMembershipInput(RWModel):  # pylint: disable=too-few-public-methods
-    """Input model for sample group membership."""
-
-    sample_id: list[str] = Field(..., description="Sample id")

--- a/api/bonsai_api/routers/groups.py
+++ b/api/bonsai_api/routers/groups.py
@@ -1,5 +1,6 @@
 """Entrypoints for getting group data."""
 
+from itertools import groupby
 import bonsai_api.crud.group as crud_gr
 import bonsai_api.crud.memberships as crud_mem
 from api_client.audit_log import AuditLogClient
@@ -71,9 +72,9 @@ async def build_column_definitions(
 
     if include_metadata and db and group_obj:
         # TODO remove additional db query
-        links = await get_samples_by_group_ids(group_ids=[group_obj.group_id], db=db)
+        edges = await get_samples_by_group_ids([group_obj.group_id], db=db)
         meta_entries = await get_metadata_fields_for_samples(
-            db, sample_ids=links[0].sample_ids
+            db, sample_ids=[e.sample_id for e in edges]
         )
         columns += meta_entries
 
@@ -307,16 +308,17 @@ async def get_samples_in_group(
     """Get basic prediction results of all samples in a group."""
     # get group info
     try:
-        memberships = await crud_mem.get_samples_by_group_ids([group_id], db=db)
+        memberships_edges = await crud_mem.get_samples_by_group_ids([group_id], db=db)
     except EntryNotFound as error:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=group_id,
         ) from error
     # query samples
+    samples_in_group = [edge.sample_id for edge in memberships_edges]
     db_obj: MultipleRecordsResponseModel = await get_samples_summary(
         db,
-        include_samples=memberships[0].sample_ids,
+        include_samples=samples_in_group,
         limit=limit,
         skip=skip,
         prediction_result=prediction_result,

--- a/api/bonsai_api/routers/groups.py
+++ b/api/bonsai_api/routers/groups.py
@@ -213,7 +213,7 @@ async def add_samples_to_group(
     """Add one or more samples to a group"""
     # cast input information as group db object
     try:
-        # reformat the request to edges and perofrm mutation
+        # reformat the request to edges and perform mutation
         edges = [
             MembershipEdge(sample_id=sid, group_id=group_id) for sid in sample_ids
         ]

--- a/api/bonsai_api/routers/groups.py
+++ b/api/bonsai_api/routers/groups.py
@@ -1,24 +1,31 @@
 """Entrypoints for getting group data."""
 
-import bonsai_api.crud.group as crud_group
+import bonsai_api.crud.group as crud_gr
+import bonsai_api.crud.memberships as crud_mem
 from api_client.audit_log import AuditLogClient
 from bonsai_api.crud.errors import DatabaseOperationError, EntryNotFound
-from bonsai_api.crud.group import create_group as create_group_record
-from bonsai_api.crud.group import (delete_group, get_group, get_groups,
-                                   update_group)
 from bonsai_api.crud.metadata import get_metadata_fields_for_samples
 from bonsai_api.crud.sample import get_samples_summary
 from bonsai_api.db import Database
-from bonsai_api.dependencies import (get_audit_log, get_current_active_user,
-                                     get_database, get_request_context)
+from bonsai_api.dependencies import (
+    get_audit_log,
+    get_current_active_user,
+    get_database,
+    get_request_context,
+)
 from bonsai_api.models.base import MultipleRecordsResponseModel
 from bonsai_api.models.context import ApiRequestContext
-from bonsai_api.models.group import (DEFAULT_COLUMNS, GroupInCreate,
-                                     GroupInfoDatabase, SampleTableColumnInput,
-                                     pred_res_cols, qc_cols)
+from bonsai_api.models.group import (
+    DEFAULT_COLUMNS,
+    GroupInCreate,
+    GroupInfoDatabase,
+    SampleTableColumnInput,
+    pred_res_cols,
+    qc_cols,
+)
+from bonsai_api.models.memberships import SampleGroupLink
 from bonsai_api.models.user import UserOutputDatabase
-from fastapi import (APIRouter, Depends, HTTPException, Path, Query, Security,
-                     status)
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, Security, status
 from fastapi.encoders import jsonable_encoder
 from pymongo.errors import DuplicateKeyError
 
@@ -86,7 +93,7 @@ async def get_groups_in_db(
     ),
 ):
     """Get information of the number of samples per group loaded into the database."""
-    groups = await get_groups(db)
+    groups = await crud_gr.get_groups(db)
     return groups
 
 
@@ -107,7 +114,7 @@ async def create_group(
 ):
     """Create a new group document in the database"""
     try:
-        result = await create_group_record(db, group_info, req_ctx, audit_log)
+        result = await crud_gr.create_group(db, group_info, req_ctx, audit_log)
     except DuplicateKeyError as error:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -130,7 +137,7 @@ async def get_group_in_db(
     ),
 ):
     """Get information of the number of samples per group loaded into the database."""
-    group = await get_group(db, group_id, lookup_samples=lookup_samples)
+    group = await crud_gr.get_group(db, group_id, lookup_samples=lookup_samples)
     return group
 
 
@@ -150,7 +157,7 @@ async def delete_group_from_db(
 ):
     """Delete a group from the database."""
     try:
-        result = await delete_group(db, group_id, req_ctx, audit_log)
+        result = await crud_gr.delete_group(db, group_id, req_ctx, audit_log)
     except EntryNotFound as error:
         raise HTTPException(
             status_code=404, detail=f"Group with id: {group_id} not in database"
@@ -173,8 +180,9 @@ async def update_group_info(
 ):
     """Update information of an group in the database."""
     # cast input information as group db object
+    # TODO define which parameters that are allowed to change
     try:
-        await update_group(db, group_id, group_info, req_ctx, audit_log)
+        await crud_gr.update_group(db, group_id, group_info, req_ctx, audit_log)
     except EntryNotFound as error:
         raise HTTPException(
             status_code=404, detail=f"Group with id: {group_id} not in database"
@@ -202,9 +210,10 @@ async def add_samples_to_group(
     """Add one or more samples to a group"""
     # cast input information as group db object
     try:
-        await crud_group.add_samples_to_group(
-            db, group_id, sample_ids, req_ctx, audit_log
-        )
+        links = [
+            SampleGroupLink(sample_id=sid, group_ids=[group_id]) for sid in sample_ids
+        ]
+        await crud_mem.add_memberships(db, links)
     except EntryNotFound as error:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -237,9 +246,10 @@ async def remove_sample_from_group(
     """Add one or more samples to a group"""
     # cast input information as group db object
     try:
-        await crud_group.remove_samples_from_group(
-            db, group_id, sample_ids, req_ctx, audit_log
-        )
+        links = [
+            SampleGroupLink(sample_id=sid, group_ids=[group_id]) for sid in sample_ids
+        ]
+        await crud_mem.remove_memberships(db, links)
     except EntryNotFound as error:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -265,7 +275,7 @@ async def get_columns_for_group(
 ):
     """Get information of the number of samples per group loaded into the database."""
     group_obj = GroupInfoDatabase.model_validate(
-        await get_group(db, group_id, lookup_samples=False)
+        await crud_gr.get_group(db, group_id, lookup_samples=False)
     )
     columns = await build_column_definitions(
         group_obj=group_obj, include_metadata=True, db=db
@@ -293,7 +303,7 @@ async def get_samples_in_group(
     """Get basic prediction results of all samples in a group."""
     # get group info
     try:
-        group = await get_group(db, group_id, lookup_samples=False)
+        memberships = await crud_mem.get_samples_by_group_ids(db, [group_id])
     except EntryNotFound as error:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -302,7 +312,7 @@ async def get_samples_in_group(
     # query samples
     db_obj: MultipleRecordsResponseModel = await get_samples_summary(
         db,
-        include_samples=group.included_samples,
+        include_samples=memberships[0].sample_ids,
         limit=limit,
         skip=skip,
         prediction_result=prediction_result,

--- a/api/bonsai_api/routers/groups.py
+++ b/api/bonsai_api/routers/groups.py
@@ -6,6 +6,7 @@ from api_client.audit_log import AuditLogClient
 from bonsai_api.crud.errors import DatabaseOperationError, EntryNotFound
 from bonsai_api.crud.metadata import get_metadata_fields_for_samples
 from bonsai_api.crud.sample import get_samples_summary
+from bonsai_api.crud.memberships import get_samples_by_group_ids
 from bonsai_api.db import Database
 from bonsai_api.dependencies import (
     get_audit_log,
@@ -23,7 +24,7 @@ from bonsai_api.models.group import (
     pred_res_cols,
     qc_cols,
 )
-from bonsai_api.models.memberships import SampleGroupLink
+from bonsai_api.models.memberships import MembershipEdge
 from bonsai_api.models.user import UserOutputDatabase
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, Security, status
 from fastapi.encoders import jsonable_encoder
@@ -69,8 +70,10 @@ async def build_column_definitions(
         columns = [idx_base_cols[col_id] for col_id in DEFAULT_COLUMNS]
 
     if include_metadata and db and group_obj:
+        # TODO remove additional db query
+        links = await get_samples_by_group_ids(group_ids=[group_obj.group_id], db=db)
         meta_entries = await get_metadata_fields_for_samples(
-            db, sample_ids=group_obj.included_samples
+            db, sample_ids=links[0].sample_ids
         )
         columns += meta_entries
 
@@ -130,14 +133,13 @@ async def create_group(
 )
 async def get_group_in_db(
     group_id: str,
-    lookup_samples: bool = False,
     db: Database = Depends(get_database),
     current_user: UserOutputDatabase = Security(  # pylint: disable=unused-argument
         get_current_active_user, scopes=[READ_PERMISSION]
     ),
 ):
     """Get information of the number of samples per group loaded into the database."""
-    group = await crud_gr.get_group(db, group_id, lookup_samples=lookup_samples)
+    group = await crud_gr.get_group(db, group_id)
     return group
 
 
@@ -210,10 +212,11 @@ async def add_samples_to_group(
     """Add one or more samples to a group"""
     # cast input information as group db object
     try:
-        links = [
-            SampleGroupLink(sample_id=sid, group_ids=[group_id]) for sid in sample_ids
+        # reformat the request to edges and perofrm mutation
+        edges = [
+            MembershipEdge(sample_id=sid, group_id=group_id) for sid in sample_ids
         ]
-        await crud_mem.add_memberships(db, links)
+        await crud_mem.add_memberships(edges, db=db)
     except EntryNotFound as error:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -246,10 +249,11 @@ async def remove_sample_from_group(
     """Add one or more samples to a group"""
     # cast input information as group db object
     try:
-        links = [
-            SampleGroupLink(sample_id=sid, group_ids=[group_id]) for sid in sample_ids
+        # build edges of the groups to remove
+        edges = [
+            MembershipEdge(sample_id=sid, group_id=group_id) for sid in sample_ids
         ]
-        await crud_mem.remove_memberships(db, links)
+        await crud_mem.remove_memberships(edges, db=db)
     except EntryNotFound as error:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -303,7 +307,7 @@ async def get_samples_in_group(
     """Get basic prediction results of all samples in a group."""
     # get group info
     try:
-        memberships = await crud_mem.get_samples_by_group_ids(db, [group_id])
+        memberships = await crud_mem.get_samples_by_group_ids([group_id], db=db)
     except EntryNotFound as error:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/api/bonsai_api/routers/memberships.py
+++ b/api/bonsai_api/routers/memberships.py
@@ -2,10 +2,10 @@
 
 import logging
 
-from bonsai_api.crud.memberships import get_samples_group_membership
+from bonsai_api.crud.memberships import get_groups_by_sample_ids, get_samples_by_group_ids
 from bonsai_api.db import Database
 from bonsai_api.dependencies import get_current_active_user, get_database
-from bonsai_api.models.memberships import MembershipsQueryResponse
+from bonsai_api.models.memberships import GroupSampleLink, SampleGroupLink
 from bonsai_api.models.user import UserOutputDatabase
 from bonsai_api.routers.shared import RouterTags
 from fastapi import APIRouter, Depends, HTTPException, Query, Security, status
@@ -22,8 +22,8 @@ UPDATE_PERMISSION = "groups:update"
 
 @router.get(
     "/memberships",
-    response_model=MembershipsQueryResponse,
-    tags=[RouterTags.SAMPLE, RouterTags.GROUP],
+    response_model=list[GroupSampleLink] | list[SampleGroupLink],
+    tags=[RouterTags.MEM, RouterTags.SAMPLE, RouterTags.GROUP],
 )
 async def get_group_membership(
     db: Database = Depends(get_database),
@@ -51,11 +51,14 @@ async def get_group_membership(
         )
 
     max_ids = 100
-    if len(sample_ids) > max_ids:
+    ids = sample_ids or group_ids
+    if len(ids) > max_ids:
         raise HTTPException(
             status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
             detail=f"Too many IDs provided ({len(sample_ids)}). Maximum allowed is {max_ids}.",
         )
-
-    memberships = await get_samples_group_membership(db, sample_ids)
-    return memberships
+    
+    if sample_ids:
+        return await get_groups_by_sample_ids(db, sample_ids)
+    return await get_samples_by_group_ids(db, group_ids)
+    

--- a/api/bonsai_api/routers/memberships.py
+++ b/api/bonsai_api/routers/memberships.py
@@ -2,10 +2,13 @@
 
 import logging
 
-from bonsai_api.crud.memberships import get_groups_by_sample_ids, get_samples_by_group_ids
+from bonsai_api.crud.memberships import (
+    get_groups_by_sample_ids,
+    get_samples_by_group_ids,
+)
 from bonsai_api.db import Database
 from bonsai_api.dependencies import get_current_active_user, get_database
-from bonsai_api.models.memberships import GroupSampleLink, SampleGroupLink
+from bonsai_api.models.memberships import MembershipEdges
 from bonsai_api.models.user import UserOutputDatabase
 from bonsai_api.routers.shared import RouterTags
 from fastapi import APIRouter, Depends, HTTPException, Query, Security, status
@@ -22,7 +25,7 @@ UPDATE_PERMISSION = "groups:update"
 
 @router.get(
     "/memberships",
-    response_model=list[GroupSampleLink] | list[SampleGroupLink],
+    response_model=MembershipEdges,
     tags=[RouterTags.MEM, RouterTags.SAMPLE, RouterTags.GROUP],
 )
 async def get_group_membership(
@@ -30,10 +33,10 @@ async def get_group_membership(
     current_user: UserOutputDatabase = Security(
         get_current_active_user, scopes=[READ_PERMISSION]
     ),
-    sample_ids: list[str] = Query(
+    sample_ids: list[str] | None = Query(
         None, alias="s", description="Sample IDs to check group membership"
     ),
-    group_ids: list[str] = Query(
+    group_ids: list[str] | None = Query(
         None, alias="g", description="Check samples that are members of groups with IDs"
     ),
 ):
@@ -55,10 +58,9 @@ async def get_group_membership(
     if len(ids) > max_ids:
         raise HTTPException(
             status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
-            detail=f"Too many IDs provided ({len(sample_ids)}). Maximum allowed is {max_ids}.",
+            detail=f"Too many IDs provided ({len(ids)}). Maximum allowed is {max_ids}.",
         )
-    
+
     if sample_ids:
-        return await get_groups_by_sample_ids(db, sample_ids)
-    return await get_samples_by_group_ids(db, group_ids)
-    
+        return await get_groups_by_sample_ids(sample_ids, db=db)
+    return await get_samples_by_group_ids(group_ids, db=db)

--- a/api/bonsai_api/routers/memberships.py
+++ b/api/bonsai_api/routers/memberships.py
@@ -1,0 +1,62 @@
+"""Query and manage many-to-many relationships between samples and groups"""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Security, status
+
+from bonsai_api.db import Database
+from bonsai_api.dependencies import get_current_active_user, get_database
+from bonsai_api.routers.shared import RouterTags
+from bonsai_api.crud.memberships import get_samples_group_membership
+from bonsai_api.models.memberships import MembershipsQueryResponse
+from bonsai_api.models.user import UserOutputDatabase
+
+LOG = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+READ_PERMISSION = "groups:read"
+WRITE_PERMISSION = "groups:write"
+UPDATE_PERMISSION = "groups:update"
+
+
+@router.get(
+    "/memberships",
+    response_model=MembershipsQueryResponse,
+    tags=[RouterTags.SAMPLE, RouterTags.GROUP],
+)
+async def get_group_membership(
+    db: Database = Depends(get_database),
+    current_user: UserOutputDatabase = Security(
+        get_current_active_user, scopes=[READ_PERMISSION]
+    ),
+    sids: list[str] = Query(
+        None, description="Sample IDs to check group membership"
+    ),
+    gids: list[str] = Query(
+        None, description="Check samples that are members of groups with IDs"
+    ),
+):
+    """Get group membership for multiple samples."""
+    if sids and gids:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            detail="You must provide either sample IDs or group IDs."
+        )
+
+    if not sids and not gids:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            detail="Neither sample IDs nor group IDs provided."
+        )
+
+    max_ids = 100
+    if len(sids) > max_ids:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"Too many IDs provided ({len(sids)}). Maximum allowed is {max_ids}.",
+        )
+
+    memberships = await get_samples_group_membership(db, sids)
+    return memberships

--- a/api/bonsai_api/routers/memberships.py
+++ b/api/bonsai_api/routers/memberships.py
@@ -2,14 +2,13 @@
 
 import logging
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Security, status
-
+from bonsai_api.crud.memberships import get_samples_group_membership
 from bonsai_api.db import Database
 from bonsai_api.dependencies import get_current_active_user, get_database
-from bonsai_api.routers.shared import RouterTags
-from bonsai_api.crud.memberships import get_samples_group_membership
 from bonsai_api.models.memberships import MembershipsQueryResponse
 from bonsai_api.models.user import UserOutputDatabase
+from bonsai_api.routers.shared import RouterTags
+from fastapi import APIRouter, Depends, HTTPException, Query, Security, status
 
 LOG = logging.getLogger(__name__)
 
@@ -31,32 +30,32 @@ async def get_group_membership(
     current_user: UserOutputDatabase = Security(
         get_current_active_user, scopes=[READ_PERMISSION]
     ),
-    sids: list[str] = Query(
-        None, description="Sample IDs to check group membership"
+    sample_ids: list[str] = Query(
+        None, alias="s", description="Sample IDs to check group membership"
     ),
-    gids: list[str] = Query(
-        None, description="Check samples that are members of groups with IDs"
+    group_ids: list[str] = Query(
+        None, alias="g", description="Check samples that are members of groups with IDs"
     ),
 ):
     """Get group membership for multiple samples."""
-    if sids and gids:
+    if sample_ids and group_ids:
         raise HTTPException(
             status.HTTP_400_BAD_REQUEST,
-            detail="You must provide either sample IDs or group IDs."
+            detail="You must provide either sample IDs or group IDs.",
         )
 
-    if not sids and not gids:
+    if not sample_ids and not group_ids:
         raise HTTPException(
             status.HTTP_400_BAD_REQUEST,
-            detail="Neither sample IDs nor group IDs provided."
+            detail="Neither sample IDs nor group IDs provided.",
         )
 
     max_ids = 100
-    if len(sids) > max_ids:
+    if len(sample_ids) > max_ids:
         raise HTTPException(
             status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
-            detail=f"Too many IDs provided ({len(sids)}). Maximum allowed is {max_ids}.",
+            detail=f"Too many IDs provided ({len(sample_ids)}). Maximum allowed is {max_ids}.",
         )
 
-    memberships = await get_samples_group_membership(db, sids)
+    memberships = await get_samples_group_membership(db, sample_ids)
     return memberships

--- a/api/bonsai_api/routers/samples.py
+++ b/api/bonsai_api/routers/samples.py
@@ -5,51 +5,92 @@ import pathlib
 from typing import Annotated, Any, Union, cast
 
 from api_client.audit_log.client import AuditLogClient
-from bonsai_api.crud.group import get_samples_group_membership
 from bonsai_api.crud.metadata import add_metadata_to_sample
-from bonsai_api.crud.sample import EntryNotFound, add_comment, add_location
+from bonsai_api.crud.sample import (
+    EntryNotFound,
+    add_comment,
+    add_location,
+)
 from bonsai_api.crud.sample import create_sample as create_sample_record
 from bonsai_api.crud.sample import delete_samples as delete_samples_from_db
-from bonsai_api.crud.sample import get_sample, get_samples_summary
+from bonsai_api.crud.sample import (
+    get_sample,
+    get_samples_summary,
+)
 from bonsai_api.crud.sample import hide_comment as hide_comment_for_sample
 from bonsai_api.crud.sample import update_sample as crud_update_sample
-from bonsai_api.crud.sample import (update_sample_qc_classification,
-                                    update_variant_annotation_for_sample)
+from bonsai_api.crud.sample import (
+    update_sample_qc_classification,
+    update_variant_annotation_for_sample,
+)
 from bonsai_api.db import Database
-from bonsai_api.dependencies import (get_audit_log, get_current_active_user,
-                                     get_database, get_request_context)
-from bonsai_api.io import (InvalidRangeError, RangeOutOfBoundsError,
-                           is_file_readable, send_partial_file)
+from bonsai_api.dependencies import (
+    get_audit_log,
+    get_current_active_user,
+    get_database,
+    get_request_context,
+)
+from bonsai_api.io import (
+    InvalidRangeError,
+    RangeOutOfBoundsError,
+    is_file_readable,
+    send_partial_file,
+)
 from bonsai_api.models.base import MultipleRecordsResponseModel
 from bonsai_api.models.cluster import TypingMethod
 from bonsai_api.models.context import ApiRequestContext
-from bonsai_api.models.group import SampleSampleGroupMemberships
 from bonsai_api.models.location import LocationOutputDatabase
 from bonsai_api.models.metadata import InputMetaEntry
 from bonsai_api.models.qc import QcClassification, VariantAnnotation
-from bonsai_api.models.sample import (Comment, CommentInDatabase,
-                                      SampleGroupMembershipInput,
-                                      SampleInCreate, SampleInDatabase)
+from bonsai_api.models.sample import (
+    Comment,
+    CommentInDatabase,
+    SampleInCreate,
+    SampleInDatabase,
+)
 from bonsai_api.models.user import UserOutputDatabase
 from bonsai_api.redis import ClusterMethod, ConnectionError
 from bonsai_api.redis.minhash import (
-    SubmittedJob, exclude_from_analysis, include_in_analysis,
-    schedule_add_genome_signature, schedule_add_genome_signature_to_index,
-    schedule_find_similar_and_cluster, schedule_find_similar_samples,
-    schedule_remove_genome_signature_from_index)
+    SubmittedJob,
+    exclude_from_analysis,
+    include_in_analysis,
+    schedule_add_genome_signature,
+    schedule_add_genome_signature_to_index,
+    schedule_find_similar_and_cluster,
+    schedule_find_similar_samples,
+    schedule_remove_genome_signature_from_index,
+)
 from bonsai_api.utils import format_error_message
-from fastapi import (APIRouter, Body, Depends, File, Header, HTTPException,
-                     Path, Query, Security, status)
+from fastapi import (
+    APIRouter,
+    Body,
+    Depends,
+    File,
+    Header,
+    HTTPException,
+    Path,
+    Query,
+    Security,
+    status,
+)
 from fastapi.responses import FileResponse
 from prp.models import PipelineResult
-from prp.models.phenotype import (AMRMethodIndex, StressMethodIndex,
-                                  VariantType, VirulenceMethodIndex)
+from prp.models.phenotype import (
+    AMRMethodIndex,
+    StressMethodIndex,
+    VariantType,
+    VirulenceMethodIndex,
+)
 from prp.models.sample import MethodIndex, ShigaTypingMethodIndex
 from pydantic import BaseModel, Field, ValidationError, model_validator
 from pymongo.errors import DuplicateKeyError
 
-from .shared import (SAMPLE_ID_PATH, RouterTags, action_from_qc_classification,
-                     parse_signature_json)
+from .shared import (
+    SAMPLE_ID_PATH,
+    RouterTags,
+    action_from_qc_classification,
+    parse_signature_json,
+)
 
 CommentsObj = list[CommentInDatabase]
 LOG = logging.getLogger(__name__)
@@ -113,49 +154,6 @@ async def samples_summary(
         qc_metrics=query.qc_metrics,
     )
     return db_obj
-
-
-@router.api_route(
-    "/samples/group-memberships",
-    response_model=SampleSampleGroupMemberships,
-    methods=["GET", "POST"],
-    tags=[RouterTags.SAMPLE],
-)
-async def get_group_membership(
-    db: Database = Depends(get_database),
-    current_user: UserOutputDatabase = Security(
-        get_current_active_user, scopes=[READ_PERMISSION]
-    ),
-    ids: list[str] = Query(
-        None, description="Sample IDs to check group membership (GET)"
-    ),
-    body: SampleGroupMembershipInput | None = Body(
-        None, description="Sample IDs to check group membership (POST)"
-    ),
-):
-    """Get group membership for multiple samples."""
-    if ids:
-        sample_ids = ids
-    elif body and body.sample_ids:
-        sample_ids = body.sample_ids
-    else:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="No sample IDs provided, either via query or body.",
-        )
-
-    # Enforce a maximum number of sample IDs to prevent abuse
-    max_samples_ids = 100
-    max_samples_post = 1000
-    max_allowed = max_samples_post if body else max_samples_ids
-    if len(sample_ids) > max_allowed:
-        raise HTTPException(
-            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
-            detail=f"Too many sample IDs provided ({len(sample_ids)}). Maximum allowed is {max_allowed}.",
-        )
-
-    memberships = await get_samples_group_membership(db, sample_ids)
-    return memberships
 
 
 @router.post("/samples/", status_code=status.HTTP_201_CREATED, tags=[RouterTags.SAMPLE])

--- a/api/bonsai_api/routers/shared.py
+++ b/api/bonsai_api/routers/shared.py
@@ -54,6 +54,7 @@ class RouterTags(StrEnum):
 
     SAMPLE = "sample"
     GROUP = "groups"
+    MEM = "memberships"
     META = "metadata"
     USR = "user"
     JOB = "jobs"

--- a/frontend/bonsai_app/blueprints/groups/templates/cell_fmt.html
+++ b/frontend/bonsai_app/blueprints/groups/templates/cell_fmt.html
@@ -138,11 +138,11 @@
     <td>{{ cell_info | join(', ') }}</td>
 {% endmacro %}
 
-{% macro in_groups_renderer(cell_info) %}
+{% macro groups_info_renderer(cell_info) %}
     <td>
     {% for gr in cell_info %}
         <span class="me-1">
-            {{ bs.pill_with_tooltip( text=gr.display_name, tooltip=gr.group_id, bg_color="info") }}
+            {{ bs.pill_with_tooltip( text=gr.display_name, tooltip=gr.id, bg_color="info") }}
         </span>
     {% endfor %}
     </td>

--- a/frontend/web/js/api.ts
+++ b/frontend/web/js/api.ts
@@ -6,9 +6,10 @@ import {
   ApiJobSubmission,
   ApiFindSimilarInput,
   GroupInfo,
-  SampleGroupMembership,
+  MembershipInfo,
   ApiUserInfo,
   ApiSampleQcStatus,
+  MembershipEdges,
 } from "./types";
 import { JobStatusEnum, TypingMethod } from "./constants";
 
@@ -211,9 +212,19 @@ export class ApiService {
     );
   };
 
-  getSampleGroupMemberships = async (sampleIds: string[], signal?: AbortSignal) => {
-    return this.http.request<SampleGroupMembership>(
-      `/samples/group-memberships?${objectToQueryParams({ ids: sampleIds })}`,
+  getMembershipByGroups = async (groupIds: string[], signal?: AbortSignal) => {
+    return this.http.request<MembershipEdges>(
+      `/memberships?${objectToQueryParams({ g: groupIds})}`,
+      {
+        method: "GET",
+        signal,
+      },
+    );
+  };
+
+  getMembershipsBySamples = async (sampleIds: string[], signal?: AbortSignal) => {
+    return this.http.request<MembershipEdges>(
+      `/memberships?${objectToQueryParams({ s: sampleIds })}`,
       {
         method: "GET",
         signal,

--- a/frontend/web/js/api.ts
+++ b/frontend/web/js/api.ts
@@ -6,7 +6,6 @@ import {
   ApiJobSubmission,
   ApiFindSimilarInput,
   GroupInfo,
-  MembershipInfo,
   ApiUserInfo,
   ApiSampleQcStatus,
   MembershipEdges,

--- a/frontend/web/js/bonsai.ts
+++ b/frontend/web/js/bonsai.ts
@@ -137,10 +137,20 @@ export async function initGroupView(
   if (deleteSamplesBtn) deleteSamplesBtn.onclick = () => deleteSelectedSamples(table, api);
 
   // lookup samples in group if provided a groupId
-  let narrow_search_to = null;
+  let filterBySamples = null;
   if (!(groupId === null || groupId === "")) {
     const group = await api.getGroup(groupId);
-    narrow_search_to = group.included_samples.length > 0 ? group.included_samples : null;
+    if ( group.sample_count > 0 ) {
+      try {
+        const controller = new AbortController();
+        const edges = await api.getMembershipByGroups([groupId], controller.signal);
+        // deduplicate ids and default to null if empty
+        const ids = Array.from(new Set(edges.map( e => e.sample_id )));
+        filterBySamples = ids.length === 0 ? null : ids
+      } catch (err) {
+        console.error("Failed to load sample-group memberships", err)
+      }
+    }
   }
 
   const selectSimilarSamplesBtn = document.getElementById(
@@ -148,7 +158,7 @@ export async function initGroupView(
   ) as HTMLButtonElement;
   if (selectSimilarSamplesBtn)
     selectSimilarSamplesBtn.onclick = () =>
-      getSimilarSamplesAndCheckRows(selectSimilarSamplesBtn, table, api, narrow_search_to);
+      getSimilarSamplesAndCheckRows(selectSimilarSamplesBtn, table, api, filterBySamples);
 
   // setup add samples to group component
   const groupSelectorContainer = document.getElementById(
@@ -158,7 +168,7 @@ export async function initGroupView(
     const addToGroupSelector = document.createElement("group-selector") as GroupSelector;
     addToGroupSelector.getGroupInfo = api.getGroups;
     addToGroupSelector.getSelectedSamples = table.getSelectedRows.bind(table);
-    addToGroupSelector.getGroupMembership = api.getSampleGroupMemberships;
+    addToGroupSelector.getGroupMembership = api.getMembershipsBySamples;
     addToGroupSelector.addToGroup = api.addSamplesToGroup;
 
     // set up listners for updates and failurs

--- a/frontend/web/js/components/group-list.ts
+++ b/frontend/web/js/components/group-list.ts
@@ -10,7 +10,7 @@ function groupCardHTML(group: GroupInfo, isAdmin: boolean): string {
         <a href="${baseUrl}/groups/${group.group_id}" class="text-decoration-none text-dark">
           <div class="card-body">
             <h5 class="card-title">${group.display_name}</h5>
-            <span class="text-muted text-uppercase fw-semibold n-samples">Samples: ${group.included_samples.length}</span>
+            <span class="text-muted text-uppercase fw-semibold n-samples">Samples: ${group.sample_count}</span>
             ${group.description ? `<p class="card-text text-wrap">${group.description}</p>` : ""}
           </div>
           <div class="card-footer text-body-secondary text-muted py-1 text-uppercase fw-semibold">

--- a/frontend/web/js/components/group-selector.ts
+++ b/frontend/web/js/components/group-selector.ts
@@ -1,5 +1,5 @@
 import { emitEvent } from "../utils/event-bus";
-import { GroupInfo, SampleGroupMembership } from "../types";
+import { GroupInfo, MembershipInfo } from "../types";
 import { ChoiceSelect } from "../utils/choice-select";
 
 const template = document.createElement("template");
@@ -23,7 +23,7 @@ export class GroupSelector extends HTMLElement {
   getGroupInfo: (() => Promise<GroupInfo[]>) | null = null;
   getSelectedSamples: (() => string[]) | null = null;
   getGroupMembership:
-    | ((sampleIds: string[], signal?: AbortSignal) => Promise<SampleGroupMembership[]>)
+    | ((sampleIds: string[], signal?: AbortSignal) => Promise<MembershipInfo[]>)
     | null = null;
   addToGroup: ((groupId: string, sampleIds: string[]) => Promise<void>) | null = null;
 
@@ -39,7 +39,7 @@ export class GroupSelector extends HTMLElement {
     this.attachShadow({ mode: "open" });
     this.shadow = this.shadowRoot!;
     this.shadow.appendChild(template.content.cloneNode(true));
-    this.selector = this.shadow.getElementById("groups");
+    this.selector = this.shadow.getElementById("groups") as ChoiceSelect;
     this.applyBtn = this.shadow.getElementById("apply") as HTMLButtonElement;
     this.clearBtn = this.shadow.getElementById("clear") as HTMLButtonElement;
   }

--- a/frontend/web/js/components/group-selector.ts
+++ b/frontend/web/js/components/group-selector.ts
@@ -1,5 +1,5 @@
 import { emitEvent } from "../utils/event-bus";
-import { GroupInfo, MembershipInfo } from "../types";
+import { GroupInfo, MembershipEdges } from "../types";
 import { ChoiceSelect } from "../utils/choice-select";
 
 const template = document.createElement("template");
@@ -23,7 +23,7 @@ export class GroupSelector extends HTMLElement {
   getGroupInfo: (() => Promise<GroupInfo[]>) | null = null;
   getSelectedSamples: (() => string[]) | null = null;
   getGroupMembership:
-    | ((sampleIds: string[], signal?: AbortSignal) => Promise<MembershipInfo[]>)
+    | ((sampleIds: string[], signal?: AbortSignal) => Promise<MembershipEdges>)
     | null = null;
   addToGroup: ((groupId: string, sampleIds: string[]) => Promise<void>) | null = null;
 
@@ -113,23 +113,54 @@ export class GroupSelector extends HTMLElement {
     }
 
     try {
-      const memberships = await this.getGroupMembership(sampleIds, this.membershipAbort.signal);
+      const membershipsEdges = await this.getGroupMembership(sampleIds, this.membershipAbort.signal);
+      const memberships = groupMemberships(membershipsEdges)
       const counts = new Map<string, number>();
+      const nSamples = sampleIds.length;
+
       for (const sid of sampleIds) {
-        for (const gid of memberships[sid] ?? []) {
+        // Dedupe groups within a sample to avoid overcounting
+        const groupsForSample = new Set(memberships[sid] ?? []);
+        for (const gid of groupsForSample) {
           counts.set(gid, (counts.get(gid) ?? 0) + 1);
         }
       }
-      // calculate the number of groups in total and
-      const nSamples = sampleIds.length;
+
       const groupNameIntersect = [...counts.entries()]
         .filter(([_, cnt]) => cnt === nSamples)
-        .map(([gid]) => gid);
+        .map(([gid]) =>  gid);
+
+      groupNameIntersect.sort()
       this.selector.setSelected(groupNameIntersect);
     } catch (err) {
       console.warn("Failed to preselect samples", err);
     }
   }
 }
+
+
+type MembershipBySample = Record<string, string[]>;
+
+
+function groupMemberships(
+  edges: MembershipEdges,
+  { dedupe = true, sort = true } = {}
+): MembershipBySample {
+  const map = new Map<string, Set<string>>();
+
+  for (const { sample_id, group_id } of edges) {
+    const set = map.get(sample_id) ?? new Set<string>();
+    set.add(group_id);
+    map.set(sample_id, set);
+  }
+
+  const result: MembershipBySample = {};
+  for (const [sample_id, set] of map.entries()) {
+    const arr = Array.from(set);
+    result[sample_id] = sort ? arr.sort() : arr;
+  }
+  return result;
+}
+
 
 customElements.define("group-selector", GroupSelector);

--- a/frontend/web/js/types.ts
+++ b/frontend/web/js/types.ts
@@ -105,6 +105,8 @@ export interface ApiUserInfo {
   authentication_method: string;
 }
 
+export type MembershipEdge = {sample_id: string, group_id: string};
+export type MembershipEdges = MembershipEdge[];
+
 export type CallbackFunc = (ids: string[]) => void;
 export type TblStateCallbackFunc = (selectedRows: string[]) => void;
-export type SampleGroupMembership = Record<string, string[]>;

--- a/frontend/web/js/types.ts
+++ b/frontend/web/js/types.ts
@@ -68,7 +68,7 @@ export interface GroupInfo {
   group_id: string;
   display_name: string;
   description: string;
-  included_samples: string[];
+  sample_count: number;
   table_columns: ColumnDefinition[];
   created_at: string;
   modified_at: string;


### PR DESCRIPTION
This PR changes how group memberships are stored and handled internally in Bonsai to simplify queries of membership. Group membership is a many-to-many relationship as samples can be a member of many groups and we want to support queries of which groups a set of samples are members of as well as which samples are members of these groups. 

The PR includes these key changes,
 - Group memberships are now stored in the sample document, instead of the group document.
 - Added a new API entrypoint, GET /memberships for dedicated membership queries
 - Deprecated GET /groups/{group_id}/samples (now a thin convenience wrapper) and GET /group-membership in favour for GET /memberships

Additional minor changes
 - Began transition CRUD functions to support mognodb transactions
 - Began adapting TS API class to support `AbortController`