### PR TITLE
Option to create admin user on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - API can automatically create an admin user on first startup if `BONSAI_ADMIN_USER` and `BONSAI_ADMIN_PASSWORD` is set.
+- Database indexes are now created automatically on API startup.
 - Added a GET /memberships router for querying samples belonging to groups and vice versa.
 - Show groups a sample is a member of in the sample table.
 - Added button for showing only selected rows in the sample table

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- API can automatically create an admin user on first startup if `BONSAI_ADMIN_USER` and `BONSAI_ADMIN_PASSWORD` is set.
 - Added a GET /memberships router for querying samples belonging to groups and vice versa.
 - Show groups a sample is a member of in the sample table.
 - Added button for showing only selected rows in the sample table

--- a/api/bonsai_api/cli/cli_tasks.py
+++ b/api/bonsai_api/cli/cli_tasks.py
@@ -10,7 +10,7 @@ from api_client.audit_log.models import Actor, SourceType
 from bonsai_api.config import settings
 from bonsai_api.crud.sample import get_samples_full, update_sample
 from bonsai_api.crud.tags import compute_phenotype_tags
-from bonsai_api.crud.user import create_user as create_user_in_db
+from bonsai_api.services.user_service import create_user_service
 from bonsai_api.db import verify
 from bonsai_api.db.index import INDEXES
 from bonsai_api.db.utils import get_db_connection
@@ -58,7 +58,7 @@ async def run_create_user(user_obj: UserInputCreate) -> UserOutputDatabase:
     audit_log = _get_audit_log_client()
     LOG.info("Creating user: %s", user_obj.username)
     async with get_db_connection() as db:
-        return await create_user_in_db(db, user_obj, ctx, audit_log)
+        return await create_user_service(db, user_obj, ctx, audit_log)
 
 
 async def run_create_group(group_obj: GroupInfoCreate, user_id: str) -> GroupInfoOut:

--- a/api/bonsai_api/config.py
+++ b/api/bonsai_api/config.py
@@ -134,6 +134,12 @@ class QCConfig(BaseModel):
 class Settings(BaseSettings):
     """API configuration."""
 
+    # Options for creating a admin user on first startup.
+    # Its useful when running Bonsai in a containerized environment
+    bonsai_admin_user: str | None = None
+    bonsai_admin_password: str | None = None
+    bonsai_admin_mail: str | None = None
+
     # Configure allowed origins (CORS) for development. Origins are a comma seperated list.
     # https://fastapi.tiangolo.com/tutorial/cors/
     allowed_origins: list[str] = []

--- a/api/bonsai_api/crud/user.py
+++ b/api/bonsai_api/crud/user.py
@@ -130,30 +130,20 @@ async def update_user(
 
 async def create_user(
     db_obj: Database,
-    user: UserInputCreate,
-    ctx: ApiRequestContext,
-    audit: AuditLogClient | None = None,
+    user: UserInputDatabase,
 ) -> UserOutputDatabase:
-    """Create new user in the database."""
-    event_subject = Subject(id=user.username, type=SourceType.SYS)
-    with audit_event_context(audit, "create_user", ctx, event_subject):
-        # create hash for password
-        hashed_password = get_password_hash(user.password)
-        user_db_fmt: UserInputDatabase = UserInputDatabase(
-            hashed_password=hashed_password, **user.model_dump()
-        )
-        # store data in database
-        try:
-            resp_obj = await db_obj.user_collection.insert_one(user_db_fmt.model_dump())
-        except DuplicateKeyError as exc:
-            LOG.error("User %s already exists: %s", user.username, str(exc))
-            raise ConflictError(f"User {user.username} already exists") from exc
-        inserted_id = resp_obj.inserted_id
-        user_obj = UserInputDatabase(
-            id=str(inserted_id),
-            **user_db_fmt.model_dump(),
-        )
-    return user_obj
+    """Insert a user document into the database."""
+    try:
+        resp_obj = await db_obj.user_collection.insert_one(user.model_dump())
+    except DuplicateKeyError as exc:
+        LOG.error("User %s already exists: %s", user.username, str(exc))
+        raise ConflictError(f"User {user.username} already exists") from exc
+
+    inserted_id = resp_obj.inserted_id
+    return UserOutputDatabase(
+        id=str(inserted_id),
+        **user.model_dump(exclude={"hashed_password"}),
+    )
 
 
 async def get_users(

--- a/api/bonsai_api/main.py
+++ b/api/bonsai_api/main.py
@@ -7,6 +7,7 @@ from contextlib import asynccontextmanager
 from api_client.audit_log import AuditLogClient
 from api_client.notification import NotificationClient
 from bonsai_api.db.db import setup_db_connection
+from bonsai_api.services.user_service import create_user_on_startup
 from fastapi import FastAPI
 
 from .config import Settings, settings
@@ -72,6 +73,30 @@ async def lifespan(app: FastAPI):
             base_url=str(settings.notification_service_api)
         )
 
+    if settings.bonsai_admin_user:
+
+        if not settings.bonsai_admin_password:
+            LOG.error(
+                "Admin user configured without password, skipping admin user creation."
+            )
+        else:
+            LOG.info(
+                "Admin user configured, seeding database with admin user if no users exist."
+            )
+            if await db.user_collection.count_documents({}) == 0:
+                admin_email = (
+                    settings.bonsai_admin_mail
+                    or f"{settings.bonsai_admin_user}@example.com"
+                )
+                await create_user_on_startup(
+                    db,
+                    username=settings.bonsai_admin_user,
+                    password=settings.bonsai_admin_password,
+                    email=admin_email,
+                    audit=getattr(app.state, "audit_log", None),
+                )
+                LOG.info("Created admin user %s on startup.", settings.bonsai_admin_user)
+
     yield
     # teardown
     db.close()
@@ -86,9 +111,14 @@ def create_app(settings: Settings) -> FastAPI:
     app = FastAPI(title="Bonsai", lifespan=lifespan)
     # configure CORS
     configure_cors(app)
+
     # check if api authentication is disabled
     if not settings.api_authentication:
         LOG.warning("API authentication disabled!")
+    
+    # admin user bootstrap is handled during lifespan startup
+    
+    # register routers
     app.include_router(root.router)
     app.include_router(users.router)
     app.include_router(samples.router)

--- a/api/bonsai_api/main.py
+++ b/api/bonsai_api/main.py
@@ -1,5 +1,3 @@
-"""Main entrypoint for API server."""
-
 import logging
 import logging.config as logging_config
 from contextlib import asynccontextmanager
@@ -52,6 +50,24 @@ logging_config.dictConfig(
 LOG = logging.getLogger(__name__)
 
 
+async def ensure_database_setup(db):
+    """Ensure all database indexes are created and collections are available."""
+    from bonsai_api.db.index import INDEXES
+
+    LOG.info("Ensuring database indexes are created.")
+    for col_name, indexes in INDEXES.items():
+        if col_name == "curations":
+            collection = db.curations_collection
+        else:
+            collection = getattr(db, f"{col_name}_collection")
+        for idx in indexes:
+            try:
+                await collection.create_index(idx["definition"], **idx["options"])
+                LOG.info(f"Created or ensured index {idx['options']['name']} on {col_name}")
+            except Exception as e:
+                LOG.warning(f"Failed to create index {idx['options']['name']} on {col_name}: {e}")
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Handles startup and teardown events."""
@@ -60,6 +76,8 @@ async def lifespan(app: FastAPI):
         raise RuntimeError("Database connection has not been configured")
     db = setup_db_connection(settings.mongodb_uri, db_name=settings.database_name)
     app.state.db = db
+    # ensure database indexes and collections
+    await ensure_database_setup(db)
     # setup ldap conneciton
     if settings.use_ldap_auth:
         ldap_connection.init_app()

--- a/api/bonsai_api/main.py
+++ b/api/bonsai_api/main.py
@@ -1,3 +1,12 @@
+"""
+Application entry point for the Bonsai API.
+
+This module configures logging, initialises the FastAPI application, manages
+startup and shutdown lifecycle concerns (database connections, indexes,
+external services, and optional admin bootstrapping), and registers all API
+routers, middleware, and exception handlers.
+"""
+
 import logging
 import logging.config as logging_config
 from contextlib import asynccontextmanager

--- a/api/bonsai_api/routers/users.py
+++ b/api/bonsai_api/routers/users.py
@@ -6,13 +6,13 @@ from typing import Annotated
 from api_client.audit_log.client import AuditLogClient
 from bonsai_api.crud.user import (
     add_samples_to_user_basket,
-    create_user,
     delete_user,
     get_user,
     get_users,
     remove_samples_from_user_basket,
     update_user,
 )
+from bonsai_api.services.user_service import create_user_service
 from bonsai_api.db import Database
 from bonsai_api.dependencies import (
     ApiRequestContext,
@@ -183,4 +183,4 @@ async def create_user_in_db(
     ctx: ApiRequestContext = Depends(get_request_context),
 ) -> UserOutputDatabase:
     """Create a new user."""
-    return await create_user(db, user, ctx=ctx, audit=audit_log)
+    return await create_user_service(db, user, ctx=ctx, audit=audit_log)

--- a/api/bonsai_api/services/user_service.py
+++ b/api/bonsai_api/services/user_service.py
@@ -1,0 +1,48 @@
+"""Service layer for creating and modifying user info."""
+
+from api_client.audit_log import AuditLogClient
+from api_client.audit_log.models import Actor, SourceType, Subject
+
+from bonsai_api.auth import get_password_hash
+from bonsai_api.crud.user import create_user as insert_user
+from bonsai_api.crud.utils import audit_event_context
+from bonsai_api.db import Database
+from bonsai_api.models.context import ApiRequestContext
+from bonsai_api.models.user import UserInputCreate, UserInputDatabase, UserOutputDatabase
+
+
+async def create_user_service(
+    db_obj: Database,
+    user: UserInputCreate,
+    ctx: ApiRequestContext,
+    audit: AuditLogClient | None = None,
+) -> UserOutputDatabase:
+    """Create a new user in the database with business logic applied."""
+    event_subject = Subject(id=user.username, type=SourceType.SYS)
+    with audit_event_context(audit, "create_user", ctx, event_subject):
+        hashed_password = get_password_hash(user.password)
+        user_db_fmt: UserInputDatabase = UserInputDatabase(
+            hashed_password=hashed_password, **user.model_dump(exclude="password")
+        )
+        return await insert_user(db_obj, user_db_fmt)
+
+
+async def create_user_on_startup(
+    db_obj: Database,
+    username: str,
+    password: str,
+    email: str,
+    audit: AuditLogClient | None = None,
+) -> UserOutputDatabase:
+    """Create an admin user on API startup."""
+    ctx = ApiRequestContext(
+        actor=Actor(id="system", type=SourceType.SYS),
+        metadata={},
+    )
+    user = UserInputCreate(
+        username=username,
+        password=password,
+        email=email,
+        roles=["admin"],
+    )
+    return await create_user_service(db_obj, user, ctx=ctx, audit=audit)

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Bio-Informatics",
   "Framework :: FastAPI",
 ]
-#"bonsai-prp==1.5.0",
 dependencies = [
   "bcrypt==4.1.1",
   "bonsai-prp[all] @ git+https://github.com/SMD-Bioinformatics-Lund/bonsai-prp.git@release/2.0.0",

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -12,7 +12,7 @@ Installing Bonsai using docker-compose and setup involves the following steps.
 #. :doc:`Configure LDAP based authentication (optional)</dev/login_systems>`.
 #. Start the Bonsai with ``docker-compose up -d``
 #. :ref:`Create indexes for the database<Create database indexes>`.
-#. :ref:`Create an admin user<Create an admin user>`.
+#. :ref:`Create or configure an admin user<Create an admin user>`.
 #. :ref:`Upload samples<Upload samples to Bonsai>`.
 
 Please note that your ``docker-compose.yml`` file might be different from the minimal example in the documentaiton depending on your network and server environment. You can configure the different services using environmental variables (defined in the docker-compose file). See advanced :ref:`container configuration<Container configuration>` for the available options. In rare instances you might need to  or by editing the related config files (`frontend config <https://github.com/Clinical-Genomics-Lund/bonsai/blob/master/frontend/app/config.py>`_ and `api config <https://github.com/Clinical-Genomics-Lund/bonsai/blob/master/api/app/config.py>`_) and mount these to the container using `volume mounts <https://docs.docker.com/storage/volumes/>`_.
@@ -110,6 +110,10 @@ The database must be indexed for Bonsai to work correctly. The database indexes 
 Create an admin user
 --------------------
 
+You can create an admin user either manually using the CLI or automatically on startup by configuring environment variables.
+
+**Manual Creation (CLI)**
+
 Create an admin user with the CLI. The *admin* has full permission to view, create, modify and delete data and can be used to login, upload samples, and create additional users.
 
 .. code-block:: bash
@@ -120,6 +124,26 @@ Create an admin user with the CLI. The *admin* has full permission to view, crea
                                                   --lname Holder           \
                                                   -m place.holder@mail.com \
                                                   -r admin
+
+**Automatic Creation on Startup**
+
+Alternatively, Bonsai can automatically create an admin user when the API starts up if no users exist in the database. Configure the following environment variables in your docker-compose.yml or environment:
+
+- ``BONSAI_ADMIN_USER``: Username for the admin user
+- ``BONSAI_ADMIN_PASSWORD``: Password for the admin user
+- ``BONSAI_ADMIN_MAIL``: Email for the admin user (optional, defaults to username@example.com)
+
+Example docker-compose environment configuration:
+
+.. code-block:: yaml
+
+   api:
+      environment:
+         - BONSAI_ADMIN_USER=admin
+         - BONSAI_ADMIN_PASSWORD=securepassword
+         - BONSAI_ADMIN_MAIL=admin@example.com
+
+This feature is particularly useful for containerized deployments and automated setups.
 
 Additional users can be created in the WebUI in the admin panel (``http://your-ip/admin/users``) or by using the CLI as above. For more information see :ref:`create users<Create users>`.
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -11,7 +11,6 @@ Installing Bonsai using docker-compose and setup involves the following steps.
 #. :ref:`Setup IGV (optional)<Setup IGV integration>`.
 #. :doc:`Configure LDAP based authentication (optional)</dev/login_systems>`.
 #. Start the Bonsai with ``docker-compose up -d``
-#. :ref:`Create indexes for the database<Create database indexes>`.
 #. :ref:`Create or configure an admin user<Create an admin user>`.
 #. :ref:`Upload samples<Upload samples to Bonsai>`.
 


### PR DESCRIPTION
This PR adds the option to automatically create an admin user on startup. This is useful when running Bonsai in a containerized environment and for automating the setup of a development/ testing instance.

## How to test

Set the environment variables.

- `BONSAI_ADMIN_USER`: Username for the admin user
- `BONSAI_ADMIN_PASSWORD`: Password for the admin user

Bring up a new instance of Bonsai API, 

`docker compose -f docker-compose.yml -f docker-compose.dev.yml build api && docker compose -f docker-compose.yml -f docker-compose.dev.yml up --watch api`

Try authenticating as the new user using the API, http://localhost:8001/docs#