### PR TITLE
Use parse package from bonsai-libs instead of PRP

### DIFF
--- a/api/bonsai_api/crud/cluster.py
+++ b/api/bonsai_api/crud/cluster.py
@@ -8,7 +8,7 @@ from bonsai_api.crud.builder.types import BuilderArgs, PipelineStages
 from bonsai_api.db import Database
 from bonsai_api.exceptions import EntryNotFound
 from bonsai_api.models.base import RWModel
-from prp.parse.parsers.chewbacca import replace_cgmlst_errors
+from bonsai_libs.parse.parsers.chewbacca import replace_cgmlst_errors
 
 LOG = logging.getLogger(__name__)
 

--- a/api/bonsai_api/crud/sample.py
+++ b/api/bonsai_api/crud/sample.py
@@ -21,8 +21,8 @@ from bonsai_api.models.sample import (
 from bonsai_api.utils import get_timestamp
 from bson.objectid import ObjectId
 from fastapi.encoders import jsonable_encoder
-from prp.parse.models.base import PhenotypeInfo
-from prp.parse.models.enums import AnnotationType, ElementType
+from bonsai_libs.parse.models.base import PhenotypeInfo
+from bonsai_libs.parse.models.enums import AnnotationType, ElementType
 from pymongo import ASCENDING, DESCENDING
 from pymongo.client_session import ClientSession
 from pymongo.results import UpdateResult

--- a/api/bonsai_api/crud/tags.py
+++ b/api/bonsai_api/crud/tags.py
@@ -19,8 +19,8 @@ from bonsai_api.models.tags import (
     TagType,
     VirulenceTag,
 )
-from prp.parse.models.enums import AnalysisType, ElementType
-from prp.parse.models.base import ElementTypeResult, BaseSpeciesPrediction
+from bonsai_libs.parse.models.enums import AnalysisType, ElementType
+from bonsai_libs.parse.models.base import ElementTypeResult, BaseSpeciesPrediction
 
 LOG = logging.getLogger(__name__)
 

--- a/api/bonsai_api/crud/utils.py
+++ b/api/bonsai_api/crud/utils.py
@@ -7,7 +7,7 @@ from typing import Any
 import bonsai_api
 from bonsai_libs.api_client.audit_log import AuditLogClient
 from bonsai_libs.api_client.audit_log.models import EventCreate, EventSeverity, Subject
-from bonsai_libs.api_client.core.exceptions import ApiRequestError
+from bonsai_libs.api_client.core.exceptions import ApiError
 from bonsai_api.db import Database
 from bonsai_api.exceptions import AuditLogError
 from bonsai_api.models.context import ApiRequestContext
@@ -64,7 +64,7 @@ def audit_event_context(
             )
             try:
                 audit.post_event(event)
-            except ApiRequestError as exc:
+            except ApiError as exc:
                 raise AuditLogError(
                     f"Audit log event failed for {event_type}: {exc}"
                 ) from exc

--- a/api/bonsai_api/exceptions.py
+++ b/api/bonsai_api/exceptions.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from prp.parse.exceptions import ParserError, UnsupportedVersionError, UnsupportedSoftwareError, UnsupportedAnalysisTypeError, InvalidDataFormat, SchemaMismatchError
+from bonsai_libs.parse.exceptions import ParserError, UnsupportedVersionError, UnsupportedSoftwareError, UnsupportedAnalysisTypeError, InvalidDataFormat, SchemaMismatchError
 
 
 class DomainError(Exception):

--- a/api/bonsai_api/lims_export/formatters.py
+++ b/api/bonsai_api/lims_export/formatters.py
@@ -7,8 +7,8 @@ from bonsai_api.models.analysis import CurationRecord
 from bonsai_api.models.qc import SampleQcClassification
 from bonsai_api.models.sample import SampleRecordDb
 
-from prp.parse.models.enums import AnalysisSoftware, AnalysisType
-from prp.parse.models.typing import TypingResultEmm
+from bonsai_libs.parse.models.enums import AnalysisSoftware, AnalysisType
+from bonsai_libs.parse.models.typing import TypingResultEmm
 
 from .models import Formatter, LimsAtomic, LimsComment, LimsValue
 

--- a/api/bonsai_api/models/analysis.py
+++ b/api/bonsai_api/models/analysis.py
@@ -5,9 +5,9 @@ from pydantic import BaseModel, Discriminator, Field
 
 from .base import RWModel, UUIDMixin, TimestampsMixin, AllowExtraModelMixin
 
-from prp.parse.models.base import ParserOutput as PRPParserOutput
-from prp.parse.models.enums import AnalysisType as PrpAnalysisType
-from prp.parse.models.enums import AnalysisSoftware as PrpAnalysisSoftware
+from bonsai_libs.parse.models.base import ParserOutput as PRPParserOutput
+from bonsai_libs.parse.models.enums import AnalysisType as PrpAnalysisType
+from bonsai_libs.parse.models.enums import AnalysisSoftware as PrpAnalysisSoftware
 
 
 class ResultStatus(StrEnum):

--- a/api/bonsai_api/models/sample.py
+++ b/api/bonsai_api/models/sample.py
@@ -6,9 +6,9 @@ import logging
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, computed_field, field_validator, model_validator
 
-# from prp.parse.models.base import VariantBase
-from prp.parse import hydrate_result
-from prp.parse.core.registry import get_result_model, _RESULT_MODEL_REGISTRY
+# from bonsai_libs.parse.models.base import VariantBase
+from bonsai_libs.parse import hydrate_result
+from bonsai_libs.parse.core.registry import get_result_model, _RESULT_MODEL_REGISTRY
 from pydantic_core import ValidationError
 
 from bonsai_api.models.genomic_resource import GenomicResourceDb, GenomicResourceResponse

--- a/api/bonsai_api/routers/samples/samples.py
+++ b/api/bonsai_api/routers/samples/samples.py
@@ -4,7 +4,7 @@ import logging
 
 from bonsai_libs.api_client.audit_log.client import AuditLogClient
 from bonsai_libs.api_client.audit_log.models import EventCreate, SourceType, Subject
-from bonsai_libs.api_client.core.exceptions import ApiRequestError
+from bonsai_libs.api_client.core.exceptions import ApiError
 from bonsai_api.crud.builder.summary_manifest import MANIFEST
 from bonsai_api.crud.builder.types import ManifestOutput
 from bonsai_api.crud.sample import get_samples_full
@@ -184,7 +184,7 @@ async def delete_many_samples(
         for event in audit_events:
             try:
                 audit_log.post_event(event)
-            except ApiRequestError as exc:
+            except ApiError as exc:
                 raise AuditLogError(
                     f"Audit log event failed for sample {event.subject.id}: {exc}"
                 ) from exc
@@ -248,7 +248,7 @@ async def delete_sample(
         )
         try:
             audit_log.post_event(event)
-        except ApiRequestError as exc:
+        except ApiError as exc:
             raise AuditLogError(
                 f"Audit log event failed for sample {sample_id}: {exc}"
             ) from exc

--- a/api/bonsai_api/routers/users.py
+++ b/api/bonsai_api/routers/users.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Annotated
 
-from api_client.audit_log.client import AuditLogClient
+from bonsai_libs.api_client.audit_log.client import AuditLogClient
 from bonsai_api.crud.user import (
     add_samples_to_user_basket,
     delete_user,

--- a/api/bonsai_api/services/analysis_service.py
+++ b/api/bonsai_api/services/analysis_service.py
@@ -25,9 +25,9 @@ from bonsai_api.exceptions import (
     ParserError,
     InvalidDataFormat,
 )
-from bonsai_libs.api_client.core.exceptions import ApiRequestError
+from bonsai_libs.api_client.core.exceptions import ApiError
 
-from prp.parse import run_parser
+from bonsai_libs.parse import run_parser
 
 
 LOG = logging.getLogger(__name__)
@@ -187,7 +187,7 @@ async def ingest_analysis_service(
         )
         try:
             audit.post_event(event)
-        except ApiRequestError as exc:
+        except ApiError as exc:
             raise AuditLogError(
                 f"Audit log event failed for analysis ingest on sample {sample_id}: {exc}"
             ) from exc

--- a/api/bonsai_api/services/curation_service.py
+++ b/api/bonsai_api/services/curation_service.py
@@ -12,7 +12,7 @@ from pymongo.errors import DuplicateKeyError
 from bonsai_api.utils import get_timestamp
 from bonsai_api.crud.curation import create_curation, delete_curation_crud, get_curation_by_id_crud, get_curations_crud, update_curation_crud
 from bonsai_api.exceptions import ConflictError, DatabaseOperationError, EntryNotFound, AuditLogError
-from bonsai_libs.api_client.core.exceptions import ApiRequestError
+from bonsai_libs.api_client.core.exceptions import ApiError
 from bonsai_api.crud.utils import managed_transaction
 from bonsai_api.models.context import ApiRequestContext
 from bonsai_api.models.analysis import CurationRecord, CurationCreateRecord
@@ -83,7 +83,7 @@ async def create_curation_service(
                 )
                 try:
                     audit.post_event(event)
-                except ApiRequestError as exc:
+                except ApiError as exc:
                     raise AuditLogError(
                         f"Audit log event failed for curation create {curation_id}: {exc}"
                     ) from exc
@@ -168,7 +168,7 @@ async def approve_curation_service(
         )
         try:
             audit.post_event(event)
-        except ApiRequestError as exc:
+        except ApiError as exc:
             raise AuditLogError(
                 f"Audit log event failed for curation approve {curation_id}: {exc}"
             ) from exc
@@ -207,7 +207,7 @@ async def delete_curation_service(
         )
         try:
             audit.post_event(event)
-        except ApiRequestError as exc:
+        except ApiError as exc:
             raise AuditLogError(
                 f"Audit log event failed for curation delete {curation_id}: {exc}"
             ) from exc

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 dependencies = [
   "bcrypt==4.1.1",
-  "bonsai-prp[all] @ git+https://github.com/SMD-Bioinformatics-Lund/bonsai-prp.git@release/2.0.0",
+  "bonsai-libs @ git+https://github.com/mhkc/bonsai-libs.git@master",
   "click==8.1.7",
   "fastapi[all]==0.115.0",
   "python-jose[cryptography]==3.3.0",

--- a/api/tests/crud/test_tags.py
+++ b/api/tests/crud/test_tags.py
@@ -4,9 +4,9 @@ import pytest
 from bonsai_api.crud.tags import flag_uncertain_spp_prediction
 from bonsai_api.models.tags import Tag
 from bonsai_api.models.sample import AnalysisViewEntryDb
-from prp.models.enums import AnalysisSoftware
-from prp.parse.models.bracken import BrackenSpeciesPrediction
-from prp.parse.models.mykrobe import MykrobeSpeciesPrediction
+from bonsai_libs.models.enums import AnalysisSoftware
+from bonsai_libs.parse.models.bracken import BrackenSpeciesPrediction
+from bonsai_libs.parse.models.mykrobe import MykrobeSpeciesPrediction
 from pydantic import BaseModel
 
 


### PR DESCRIPTION
Bonsai now uses the parse package from [Bonsai libs](https://github.com/mhkc/bonsai-libs).

The parse package was  [moved](https://github.com/mhkc/bonsai-libs/pull/5) from PRP to [Bonsai libs](https://github.com/mhkc/bonsai-libs) to simplifiy the chain of dependencies and reduce redundant code in the project code base.