### PR TITLE
Feature/mst clustering for ska and minhash

### DIFF
--- a/api/bonsai_api/models/enums.py
+++ b/api/bonsai_api/models/enums.py
@@ -29,11 +29,34 @@ class ExportStatus(StrEnum):
     FAILED = "failed"
 
 
-class DistanceMethod(StrEnum):  # pylint: disable=too-few-public-methods
-    """Valid distance methods for hierarchical clustering of samples."""
+class TypingMethod(StrEnum):  # pylint: disable=too-few-public-methods
+    """Supported typing methods."""
 
-    JACCARD = "jaccard"
-    HAMMING = "hamming"
+    MLST = "mlst"
+    CGMLST = "cgmlst"
+    SKA = "ska"
+    MINHASH = "minhash"
+
+
+class ClusterStrategy(StrEnum):
+    """Supported clustering strategies."""
+
+    # SDK hierarchical clustering
+    SINGLE = "single"
+    COMPLETE = "complete"
+    AVERAGE = "average"
+    WEIGHTED = "weighted"
+    CENTROID = "centroid"
+
+    # SDK MST
+    MST = "mst"
+
+    # GrapeTree
+    MSTREE_V1 = "MSTree"
+    MSTREE_V2 = "MSTreeV2"
+    NJ = "NJ"
+    RAPID_NJ = "RapidNJ"
+    NINJA = "ninja"
 
 
 class ClusterMethod(StrEnum):  # pylint: disable=too-few-public-methods
@@ -43,15 +66,6 @@ class ClusterMethod(StrEnum):  # pylint: disable=too-few-public-methods
     COMPLETE = "complete"
     AVERAGE = "average"
     NJ = "neighbor_joining"
-
-
-class TypingMethod(StrEnum):  # pylint: disable=too-few-public-methods
-    """Supported typing methods."""
-
-    MLST = "mlst"
-    CGMLST = "cgmlst"
-    SKA = "ska"
-    MINHASH = "minhash"
 
 
 class FileSources(StrEnum):

--- a/api/bonsai_api/redis/allele_cluster.py
+++ b/api/bonsai_api/redis/allele_cluster.py
@@ -1,25 +1,38 @@
 """Functions relating to scheduling allele clustering jobs."""
 
 import logging
-from typing import List
 
 import pandas as pd
 
-from . import ClusterMethod, SubmittedJob
+from bonsai_api.models.enums import ClusterStrategy
+
+from . import SubmittedJob
 from .queue import redis
 
 LOG = logging.getLogger(__name__)
 
+VALID_ALGORITHMS = [
+    ClusterStrategy.MSTREE_V1,
+    ClusterStrategy.MSTREE_V2,
+    ClusterStrategy.NJ,
+    ClusterStrategy.RAPID_NJ,
+    ClusterStrategy.NINJA,
+]
+
+def _validate_strategy(strategy: ClusterStrategy) -> None:
+    """Validate the selected stategy is valid for allele clustering."""
+    if strategy not in VALID_ALGORITHMS:
+        raise ValueError(f"Strategy: {strategy} is not supported by the allele cluster service.")
+
 
 def schedule_cluster_samples(
-    profiles: List[str], cluster_method: ClusterMethod
+    profiles: list[str], cluster_method: ClusterStrategy
 ) -> SubmittedJob:
-    """Schedule clustering on the provided allele profile.
+    """Schedule clustering on the provided allele profile."""
+    _validate_strategy(cluster_method)
 
-    :return: Information of submitted job
-    :rtype: SubmittedJob
-    """
     task = "allele_cluster_service.tasks.cluster"
+
     # convert the allele profile object to two arrays, one with names and another with
     # a tsv representation of the profile
     sample_ids = []
@@ -34,8 +47,12 @@ def schedule_cluster_samples(
         .fillna("-")  # replace nulls with MStree null char, "-"
         .to_csv(sep="\t")  # convert to tsv string
     )
+
     job = redis.allele.enqueue(
-        task, profile=profile_tsv, method=cluster_method.value, job_timeout="30m"
+        task,
+        profile=profile_tsv,
+        method=str(cluster_method),
+        job_timeout="30m"
     )
     LOG.debug("Submitting job, %s to %s", task, job.worker_name)
     return SubmittedJob(id=job.id, task=task)

--- a/api/bonsai_api/redis/minhash.py
+++ b/api/bonsai_api/redis/minhash.py
@@ -7,9 +7,12 @@ from typing import Any, Iterable
 from rq import Queue, Retry
 from rq.job import Dependency
 
-from bonsai_api.models.enums import TypingMethod
-from .models import ClusterMethod, SubmittedJob
+from bonsai_libs.clustering import ClusteringAlgorithm
+
+from bonsai_api.models.enums import TypingMethod, ClusterStrategy
+from .models import SubmittedJob
 from .queue import redis
+from .utils import _parse_linkage_method
 
 LOG = logging.getLogger(__name__)
 
@@ -185,9 +188,16 @@ def schedule_find_similar_samples(
 
 def schedule_cluster_samples(
     sample_ids: list[str],
-    cluster_method: ClusterMethod,
+    cluster_method: ClusterStrategy,
 ) -> SubmittedJob:
     """Schedule a job to cluster the given samples (no retries by default)."""
+    if ClusterStrategy == ClusterStrategy.MST:
+        algorithm = ClusteringAlgorithm.MST
+        method = None
+    else:
+        algorithm = ClusteringAlgorithm.HIERARCHICAL
+        method = str(_parse_linkage_method(str(cluster_method)))
+
     task = str(TaskName.CLUSTER_SAMPLES)
     job = enqueue_job(
         queue=redis.minhash,
@@ -195,7 +205,8 @@ def schedule_cluster_samples(
         task=task,
         retry=None,
         sample_ids=sample_ids,
-        cluster_method=cluster_method.value,
+        algorithm=str(algorithm),
+        cluster_method=method,
     )
     return SubmittedJob(id=job.id, task=task)
 
@@ -204,7 +215,7 @@ def schedule_find_similar_and_cluster(
     sample_id: str,
     min_similarity: float,
     typing_method: TypingMethod,
-    cluster_method: ClusterMethod,
+    cluster_method: ClusterStrategy,
     limit: int | None = None,
     narrow_to_sample_ids: list[str] | None = None,
 ) -> SubmittedJob:
@@ -214,8 +225,16 @@ def schedule_find_similar_and_cluster(
     min_similarity - minimum similarity score to be included
     typing_method - what data the samples should be clustered on
     """
+    # Verify input before submitting job
     if typing_method != TypingMethod.MINHASH:
         raise NotImplementedError(f"{typing_method} is not implemented yet")
+    
+    if ClusterStrategy == ClusterStrategy.MST:
+        algorithm = ClusteringAlgorithm.MST
+        method = None
+    else:
+        algorithm = ClusteringAlgorithm.HIERARCHICAL
+        method = str(_parse_linkage_method(str(cluster_method)))
 
     task = str(TaskName.SIMILAR_N_CLUSTER)
     job = enqueue_job(
@@ -227,7 +246,8 @@ def schedule_find_similar_and_cluster(
         min_similarity=min_similarity,
         limit=limit,
         subset_sample_ids=narrow_to_sample_ids,
-        cluster_method=cluster_method.value,
+        algorithm=str(algorithm),
+        cluster_method=method,
     )
     return SubmittedJob(id=job.id, task=task)
 

--- a/api/bonsai_api/redis/models.py
+++ b/api/bonsai_api/redis/models.py
@@ -1,8 +1,8 @@
 """Functions for handling redis jobs."""
 
-from enum import Enum
+from enum import StrEnum
 
-from ..models.base import RWModel
+from bonsai_api.models.base import RWModel
 
 
 class SubmittedJob(RWModel):  # pylint: disable=too-few-public-methods
@@ -11,20 +11,3 @@ class SubmittedJob(RWModel):  # pylint: disable=too-few-public-methods
     id: str
     task: str
 
-
-class ClusterMethod(Enum):  # pylint: disable=too-few-public-methods
-    """Index of methods for hierarchical clustering of samples."""
-
-    SINGLE = "single"
-    COMPLETE = "complete"
-    AVERAGE = "average"
-
-
-class MsTreeMethods(Enum):  # pylint: disable=too-few-public-methods
-    """Valid cluter methods."""
-
-    MSTREE_V1 = "MSTree"
-    MSTREE_V2 = "MSTreeV2"
-    NEIGHBOR_JOINING = "NJ"
-    RAPID_NJ = "RapidNJ"
-    NINJA = "ninja"

--- a/api/bonsai_api/redis/ska.py
+++ b/api/bonsai_api/redis/ska.py
@@ -2,22 +2,36 @@
 
 import logging
 
-from .models import ClusterMethod, SubmittedJob
+from bonsai_libs.clustering import ClusteringAlgorithm
+
+from bonsai_api.models.enums import ClusterStrategy
+
+from .utils import _parse_linkage_method
+from .models import SubmittedJob
 from .queue import redis
 
 LOG = logging.getLogger(__name__)
 
 
 def schedule_cluster_samples(
-    index_files: dict[str, str], cluster_method: ClusterMethod
+    index_files: dict[str, str], cluster_method: ClusterStrategy
 ) -> SubmittedJob:
     """Schedule SNV clustering uisng SKA."""
     task = "ska_service.tasks.cluster"
     LOG.debug("Schedule SKA clustering of %s with %s", index_files, cluster_method)
+
+    if ClusterStrategy == ClusterStrategy.MST:
+        algorithm = ClusteringAlgorithm.MST
+        method = None
+    else:
+        algorithm = ClusteringAlgorithm.HIERARCHICAL
+        method = str(_parse_linkage_method(str(cluster_method)))
+
     job = redis.ska.enqueue(
         task,
         indexes=index_files,
-        cluster_method=cluster_method.value,
+        algorithm=algorithm,
+        cluster_method=method,
         job_timeout="30m",
     )
     LOG.debug("Submitting job, %s to %s", task, job.worker_name)

--- a/api/bonsai_api/redis/utils.py
+++ b/api/bonsai_api/redis/utils.py
@@ -3,6 +3,8 @@
 import asyncio
 import logging
 
+from bonsai_libs.clustering import LinkageMethod
+
 from .models import SubmittedJob
 from .queue import JobStatus, JobStatusCodes, check_redis_job_status
 
@@ -41,3 +43,16 @@ async def wait_for_job(
         )
         raise error
     return job_status
+
+
+def _parse_linkage_method(method: str) -> LinkageMethod:
+    """Parse linkate method."""
+
+    try:
+        return LinkageMethod(method)
+    except ValueError as error:
+        LOG.error(
+            "cluster.invalid_method",
+            extra={"cluster_method": method},
+        )
+        raise ValueError(f'"{method}" is not a valid cluster method') from error

--- a/api/bonsai_api/routers/cluster.py
+++ b/api/bonsai_api/routers/cluster.py
@@ -4,6 +4,8 @@ import logging
 from pathlib import Path
 from typing import Dict
 
+from bonsai_libs.clustering import ClusteringAlgorithm, LinkageMethod
+
 from bonsai_api.crud.cluster import (
     TypingProfileOutput,
     get_signature_path_for_samples,
@@ -13,8 +15,8 @@ from bonsai_api.crud.cluster import (
 from bonsai_api.db import Database
 from bonsai_api.dependencies import get_database
 from bonsai_api.models.base import RWModel
-from bonsai_api.models.enums import DistanceMethod, TypingMethod
-from bonsai_api.redis import ClusterMethod, MsTreeMethods, SubmittedJob
+from bonsai_api.models.enums import TypingMethod, ClusterStrategy
+from bonsai_api.redis import SubmittedJob
 from bonsai_api.redis.allele_cluster import (
     schedule_cluster_samples as schedule_allele_cluster_samples,
 )
@@ -40,15 +42,11 @@ WRITE_PERMISSION = "cluster:write"
 
 
 class ClusterInput(RWModel):  # pylint: disable=too-few-public-methods
-    """Input data model for cluster entrypoint
-
-    :param RWModel: Generic read write base model
-    :type RWModel: Generic basemodel for read/ write
-    """
+    """Input data model for cluster entrypoint."""
 
     sample_ids: list[str] = Field(..., min_length=2, alias="sampleIds")
-    distance: DistanceMethod | None = None
-    method: ClusterMethod | MsTreeMethods
+
+    strategy: ClusterStrategy = ClusterStrategy.SINGLE
 
     model_config = ConfigDict(use_enum_values=False)
 

--- a/minhash_service/minhash_service/analysis/cluster.py
+++ b/minhash_service/minhash_service/analysis/cluster.py
@@ -1,47 +1,51 @@
 """Functions for clustering on minhashes"""
 
 import logging
-from typing import Any
 
 import sourmash
-from scipy.cluster import hierarchy
 
+from bonsai_libs.clustering import hierarchical_clustering, minimum_spanning_tree_clustering, LinkageMethod, ClusteringAlgorithm, ClusterResult
 from minhash_service.signatures.models import SourmashSignatures
-
-from .models import ClusterMethod
 
 LOG = logging.getLogger(__name__)
 
 
-def tree_to_newick(node, newick, parentdist, leaf_names) -> str:
-    """Convert hierarcical tree representation to newick format."""
-
-    if node.is_leaf():
-        return f"{leaf_names[node.id]}:{parentdist - node.dist:.2f}{newick}"
-
-    if len(newick) > 0:
-        newick = f"):{parentdist - node.dist:.2f}{newick}"
-    else:
-        newick = ");"
-    newick = tree_to_newick(node.get_left(), newick, node.dist, leaf_names)
-    newick = tree_to_newick(node.get_right(), f",{newick}", node.dist, leaf_names)
-    newick = f"({newick}"
-    return newick
-
-
 def cluster_signatures(
-    signatures: list[SourmashSignatures],
-    method: ClusterMethod,
+    signatures: SourmashSignatures,
+    *,
+    algorithm: ClusteringAlgorithm = ClusteringAlgorithm.HIERARCHICAL,
+    method: LinkageMethod | None = None,
     ignore_abundance: bool = True,
-) -> tuple[Any, list[str]]:
-    """Cluster multiple samples on their minhash signatures and return tree object."""
+) -> tuple[ClusterResult, list[str]]:
+    """
+    Cluster minhash signatures and return Newick + checksum order.
+    """
 
-    # create distance matrix
     similarity = sourmash.compare.compare_all_pairs(
-        signatures, ignore_abundance=ignore_abundance, n_jobs=1, return_ani=False
+        signatures,
+        ignore_abundance=ignore_abundance,
+        n_jobs=1,
+        return_ani=False,
     )
-    # cluster on similarity matrix
-    linkage = hierarchy.linkage(similarity, method=method.value)
-    tree = hierarchy.to_tree(linkage, False)
-    checksums: list[str] = [sig.md5sum() for sig in signatures]
-    return tree, checksums
+
+    checksums = [sig.md5sum() for sig in signatures]
+
+    if algorithm == ClusteringAlgorithm.HIERARCHICAL:
+        method = method or LinkageMethod.SINGLE
+
+        result = hierarchical_clustering(
+            similarity,
+            checksums,
+            method=method,
+        )
+
+    elif algorithm == ClusteringAlgorithm.MST:
+        result = minimum_spanning_tree_clustering(
+            similarity,
+            checksums,
+        )
+
+    else:
+        raise ValueError(f"Unknown clustering algorithm: {algorithm}")
+
+    return result, checksums

--- a/minhash_service/minhash_service/tasks/handlers.py
+++ b/minhash_service/minhash_service/tasks/handlers.py
@@ -7,9 +7,10 @@ import tempfile
 from pathlib import Path
 from typing import Any, Iterable, cast
 
-from minhash_service.analysis.cluster import cluster_signatures, tree_to_newick
-from minhash_service.analysis.models import (AniEstimateOptions, ClusterMethod,
-                                             SimilaritySearchConfig)
+from bonsai_libs.clustering import ClusterResult, ClusteringAlgorithm, LinkageMethod
+
+from minhash_service.analysis.cluster import cluster_signatures
+from minhash_service.analysis.models import AniEstimateOptions, SimilaritySearchConfig
 from minhash_service.analysis.similarity import get_similar_signatures
 from minhash_service.core.config import IntegrityReportLevel, cnf
 from minhash_service.core.exceptions import FileRemovalError
@@ -29,6 +30,32 @@ from minhash_service.signatures.storage import SignatureStorage
 from .notify import EmailApiInput, dispatch_email
 
 LOG = logging.getLogger(__name__)
+
+
+def _parse_cluster_algorithm(algorithm: str) -> ClusteringAlgorithm:
+    """Parse cluster algorithm."""
+
+    try:
+        return ClusteringAlgorithm(algorithm)
+    except ValueError as error:
+        LOG.error(
+            "cluster.invalid_algorithm",
+            extra={"algorithm": algorithm},
+        )
+        raise ValueError(f'"{algorithm}" is not a valid cluster algorithm') from error
+
+
+def _parse_linkage_method(method: str) -> LinkageMethod:
+    """Parse linkate method."""
+
+    try:
+        return LinkageMethod(method)
+    except ValueError as error:
+        LOG.error(
+            "cluster.invalid_method",
+            extra={"cluster_method": method},
+        )
+        raise ValueError(f'"{method}" is not a valid cluster method') from error
 
 
 def add_signature(sample_id: str, signature: str) -> str:
@@ -412,32 +439,21 @@ def search_similar(
     return result.model_dump(mode="json")
 
 
-def cluster_samples(sample_ids: list[str], cluster_method: str = "single") -> str:
+def cluster_samples(sample_ids: list[str], *, algorithm: str = "mst", cluster_method: str | None = None) -> str:
     """
     Cluster multiple sample on their sourmash signatures.
-
-    :param sample_ids list[str]: The sample ids to cluster
-    :param cluster_method int: The linkage or clustering method to use, default to single
-
-    :raises ValueError: raises an exception if the method is not a valid MSTree clustering method.
-
-    :return: clustering result in newick format
-    :rtype: str
     """
     LOG.info("Prepare to cluster %d signatures", len(sample_ids))
-    try:
-        method = ClusterMethod(cluster_method)
-    except ValueError as error:
-        msg = f'"{cluster_method}" is not a valid cluster method'
-        LOG.error(msg)
-        raise ValueError(msg) from error
+    algorithm = _parse_cluster_algorithm(algorithm)
+    method = _parse_linkage_method(cluster_method) if cluster_method else None
 
     # load sequence signatures to memory
     signatures = _load_signatures_from_sample_id(sample_ids)
 
     LOG.info("Cluster %d signatures", len(sample_ids))
-    tree, checksums  = cluster_signatures(signatures, method)
+    result, checksums  = cluster_signatures(signatures, algorithm=algorithm, method=method)
 
+    # Lookup sample ids from checksums
     repo = create_signature_repo()
     kmer_size = cnf.kmer_size
     sample_ids = []
@@ -447,46 +463,30 @@ def cluster_samples(sample_ids: list[str], cluster_method: str = "single") -> st
         if record is None:
             continue
         sample_ids.append(record.sample_id)
-
-    LOG.debug("Creating newick tree; checksums: %s; leaf names: %s", checksums, sample_ids)
-    newick = tree_to_newick(node=tree, newick="", parentdist=tree.dist, leaf_names=sample_ids)
-    return newick
+    
+    # replace labels in cluster result
+    upd_result = ClusterResult(root=result.root, labels=sample_ids)
+    return upd_result.to_newick()
 
 
 def find_similar_and_cluster(
     sample_id: str,
+    *,
     min_similarity: float = 0.5,
     limit: int | None = None,
     subset_sample_ids: list[str] | None = None,
+    algorithm: str = "hierarchical",
     cluster_method: str = "single",
 ) -> str:
-    """
-    Find similar samples and cluster them on their minhash profile.
-
-    :param sample_id str: The id of reference sample
-    :param min_similarity float: Minimum similarity score
-    :param limit int | None: Limit the result to x samples, default to None
-    :param cluster_method int: The linkage or clustering method to use, default to single
-    :param subset_sample_ids list[str] | None: Narrow the search to the following ids
-
-    :raises ValueError: raises an exception if the method is not a valid MSTree clustering method.
-
-    :return: clustering result in newick format
-    :rtype: str
-    """
-    # validate input
-    try:
-        method = ClusterMethod(cluster_method)
-    except ValueError as error:
-        msg = f'"{cluster_method}" is not a valid cluster method'
-        LOG.error(msg)
-        raise ValueError(msg) from error
+    """Find similar samples and cluster them on their minhash profile."""
     LOG.info(
         "Finding samples similar to %s with min similarity %s; limit %s",
         sample_id,
         min_similarity,
         limit,
     )
+
+    # Search similar signatures
     results = search_similar(
         sample_id=sample_id,
         min_similarity=min_similarity,
@@ -515,10 +515,13 @@ def find_similar_and_cluster(
     signatures = _load_signatures_from_sample_id(sample_ids, kmer_size=kmer_size)
 
     # cluster samples
-    LOG.info("Cluster samples...")
-    tree, checksums  = cluster_signatures(signatures, method)
-    newick = tree_to_newick(tree, "", tree.dist, [checksums_lookup.get(c, c) for c in checksums])
-    return newick
+    LOG.info("Prepare to cluster %d signatures", len(signatures))
+    algorithm = _parse_cluster_algorithm(algorithm)
+    method = _parse_linkage_method(cluster_method) if cluster_method else None
+
+    result, checksums  = cluster_signatures(signatures, algorithm=algorithm, method=method)
+    upd_result = ClusterResult(root=result.root, labels=[checksums_lookup.get(c, c) for c in checksums])
+    return upd_result.to_newick()
 
 
 def run_data_integrity_check() -> None:

--- a/minhash_service/pyproject.toml
+++ b/minhash_service/pyproject.toml
@@ -18,14 +18,15 @@ classifiers = [
 ]
 # NOTE: Removed build tools from runtime deps
 dependencies = [
-  "redis",
-  "pydantic-settings",
-  "requests",
+  "bonsai-libs @ git+https://github.com/mhkc/bonsai-sdk.git@master",
   "click==8.1.7",
+  "fasteners==0.19",
+  "pydantic-settings",
+  "pymongo==4.15.4",
+  "redis",
+  "requests",
   "rq==2.5.0",
   "sourmash==4.9.4",
-  "fasteners==0.19",
-  "pymongo==4.15.4",
 ]
 
 [project.scripts]

--- a/ska_service/pyproject.toml
+++ b/ska_service/pyproject.toml
@@ -18,13 +18,14 @@ classifiers = [
   "Framework :: RQ",
 ]
 dependencies = [
+  "biopython==1.83",
+  "bonsai-libs @ git+https://github.com/mhkc/bonsai-sdk.git@master",
+  "pandas==2.1.3",
+  "pydantic-settings==2.6.1",
+  "pydantic==2.9.0",
   "redis",
   "rq==2.5.0",
-  "pydantic==2.9.0",
-  "pydantic-settings==2.6.1",
-  "pandas==2.1.3",
   "scipy==1.14.1",
-  "biopython==1.83",
 ]
 
 [project.scripts]

--- a/ska_service/pyproject.toml
+++ b/ska_service/pyproject.toml
@@ -25,14 +25,15 @@ dependencies = [
   "pydantic==2.9.0",
   "redis",
   "rq==2.5.0",
-  "scipy==1.14.1",
 ]
 
 [project.scripts]
 ska_service = "ska_service.worker:create_app"
 
 [project.optional-dependencies]
-test = [ ]
+test = [
+  "pytest-cov",
+]
 
 [tool.setuptools.dynamic]
 version = { attr = "ska_service.__version__" }

--- a/ska_service/ska_service/ska/__init__.py
+++ b/ska_service/ska_service/ska/__init__.py
@@ -1,7 +1,7 @@
 """Wrapper for SKA2 binary."""
 
 from .base import ska_version as version
-from .cluster import ClusterMethod, cluster_distances
+from .cluster import cluster_alignment
 from .compare import ska_align as align
 from .compare import ska_distance as distance
 from .index import resolve_index_path

--- a/ska_service/ska_service/ska/cluster.py
+++ b/ska_service/ska_service/ska/cluster.py
@@ -56,16 +56,20 @@ def to_newick(
     return newick
 
 
-def calc_snv_distance(aln: MultipleSeqAlignment) -> DistanceMatrix:
+def calc_snv_distance(aln: MultipleSeqAlignment, *, ignore_gaps: bool = False) -> DistanceMatrix:
     """Calculate pair-wise sample distance from aligned fasta sequences."""
+
+    def _valid_pair(a: str, b: str, *, ignore_gaps: bool) -> bool:
+        return not ignore_gaps or (a != "-" and b != "-")
+
     dm = DistanceMatrix(names=[al.name for al in aln])
     for seq1, seq2 in itertools.combinations(aln, 2):
-        n_missing = sum(
-            a_seq != b_seq
-            for a_seq, b_seq in zip(seq1, seq2)
-            if not any([a_seq == "-", b_seq == "-"])
+        n_different = sum(
+            seq_a != seq_b
+            for seq_a, seq_b in zip(seq1, seq2)
+            if _valid_pair(seq_a, seq_b, ignore_gaps=ignore_gaps)
         )
-        dm[seq1.name, seq2.name] = n_missing
+        dm[seq1.name, seq2.name] = n_different
     return dm
 
 

--- a/ska_service/ska_service/ska/cluster.py
+++ b/ska_service/ska_service/ska/cluster.py
@@ -2,16 +2,14 @@
 
 import itertools
 import logging
-from enum import Enum
-from typing import Sequence, Any
+from typing import Any, Sequence
 
 from Bio.Align import MultipleSeqAlignment
 from Bio.Phylo.TreeConstruction import DistanceMatrix as BioDistanceMatrix
-from scipy.cluster import hierarchy
 
 LOG = logging.getLogger(__name__)
 
-TreeObj = (tuple[None, Any] | Any | None)
+TreeObj = tuple[None, Any] | Any | None
 
 
 class DistanceMatrix(BioDistanceMatrix):
@@ -24,39 +22,9 @@ class DistanceMatrix(BioDistanceMatrix):
             for seq1, seq2 in itertools.combinations(self.names, 2)
         ]
 
-
-class ClusterMethod(str, Enum):
-    """Index of methods for hierarchical clustering of samples."""
-
-    SINGLE = "single"
-    COMPLETE = "complete"
-    AVERAGE = "average"
-    WEIGHTED = "weighted"
-    CENTROID = "centroid"
-
-
-def to_newick(
-    node: hierarchy.ClusterNode,
-    newick: str,
-    parent_dist: float,
-    leaf_names: Sequence[str],
-) -> str:
-    """Convert hierarcical tree representation to newick format."""
-
-    if node.is_leaf():
-        return f"{leaf_names[node.id]}:{parent_dist - node.dist:.2f}{newick}"
-
-    if len(newick) > 0:
-        newick = f"):{parent_dist - node.dist:.2f}{newick}"
-    else:
-        newick = ");"
-    newick = to_newick(node.get_left(), newick, node.dist, leaf_names)
-    newick = to_newick(node.get_right(), f",{newick}", node.dist, leaf_names)
-    newick = f"({newick}"
-    return newick
-
-
-def calc_snv_distance(aln: MultipleSeqAlignment, *, ignore_gaps: bool = False) -> DistanceMatrix:
+def calc_snv_distance(
+    aln: MultipleSeqAlignment, *, ignore_gaps: bool = False
+) -> DistanceMatrix:
     """Calculate pair-wise sample distance from aligned fasta sequences."""
 
     def _valid_pair(a: str, b: str, *, ignore_gaps: bool) -> bool:
@@ -71,11 +39,3 @@ def calc_snv_distance(aln: MultipleSeqAlignment, *, ignore_gaps: bool = False) -
         )
         dm[seq1.name, seq2.name] = n_different
     return dm
-
-
-def cluster_distances(dm: DistanceMatrix, method: ClusterMethod) -> tuple[TreeObj, list[str]]:
-    """Cluster two or more samples from a distance matrix."""
-
-    linkage = hierarchy.linkage(dm.to_condensed(), method=method.value)
-    tree = hierarchy.to_tree(linkage, False)
-    return tree, dm.names

--- a/ska_service/ska_service/ska/cluster.py
+++ b/ska_service/ska_service/ska/cluster.py
@@ -6,6 +6,7 @@ from typing import Any, Sequence
 
 from Bio.Align import MultipleSeqAlignment
 from Bio.Phylo.TreeConstruction import DistanceMatrix as BioDistanceMatrix
+from bonsai_libs.clustering import hierarchical_clustering, minimum_spanning_tree_clustering, LinkageMethod
 
 LOG = logging.getLogger(__name__)
 
@@ -39,3 +40,30 @@ def calc_snv_distance(
         )
         dm[seq1.name, seq2.name] = n_different
     return dm
+
+
+def cluster_alignment(
+    aln: MultipleSeqAlignment,
+    sample_ids: Sequence[str],
+    *,
+    algorithm: str,
+    method: LinkageMethod | None = None,
+) -> str:
+    dm = calc_snv_distance(aln)
+    condensed = dm.to_condensed()
+
+    if algorithm == "hierarchical":
+        result = hierarchical_clustering(
+            condensed,
+            sample_ids,
+            method=method,
+        )
+    elif algorithm == "mst":
+        result = minimum_spanning_tree_clustering(
+            condensed,
+            sample_ids,
+        )
+    else:
+        raise ValueError(f"Unknown clustering algorithm: {algorithm}")
+
+    return result.to_newick()

--- a/ska_service/ska_service/ska/cluster.py
+++ b/ska_service/ska_service/ska/cluster.py
@@ -6,7 +6,7 @@ from typing import Any, Sequence
 
 from Bio.Align import MultipleSeqAlignment
 from Bio.Phylo.TreeConstruction import DistanceMatrix as BioDistanceMatrix
-from bonsai_libs.clustering import hierarchical_clustering, minimum_spanning_tree_clustering, LinkageMethod
+from bonsai_libs.clustering import hierarchical_clustering, minimum_spanning_tree_clustering, LinkageMethod, ClusteringAlgorithm
 
 LOG = logging.getLogger(__name__)
 
@@ -46,19 +46,21 @@ def cluster_alignment(
     aln: MultipleSeqAlignment,
     sample_ids: Sequence[str],
     *,
-    algorithm: str,
+    algorithm: ClusteringAlgorithm,
     method: LinkageMethod | None = None,
 ) -> str:
+    """Cluster samples on SNV alignments."""
+
     dm = calc_snv_distance(aln)
     condensed = dm.to_condensed()
 
-    if algorithm == "hierarchical":
+    if algorithm == ClusteringAlgorithm.HIERARCHICAL:
         result = hierarchical_clustering(
             condensed,
             sample_ids,
-            method=method,
+            method=method or LinkageMethod.SINGLE,
         )
-    elif algorithm == "mst":
+    elif algorithm == ClusteringAlgorithm.MST:
         result = minimum_spanning_tree_clustering(
             condensed,
             sample_ids,

--- a/ska_service/ska_service/tasks.py
+++ b/ska_service/ska_service/tasks.py
@@ -6,11 +6,10 @@ from tempfile import TemporaryDirectory
 from typing import Sequence
 
 from Bio import AlignIO
-from bonsai_libs.clustering import LinkageMethod, hierarchical_clustering, minimum_spanning_tree_clustering
+from bonsai_libs.clustering import LinkageMethod
 
 from . import ska
 from .config import settings
-from .ska.cluster import calc_snv_distance
 
 LOG = logging.getLogger(__name__)
 
@@ -26,70 +25,61 @@ def cluster(
         algorithm: str = "hierarchical",
     ) -> str:
     """
-    Cluster multiple sample on their SNVs using SKA indexes.
-
-    :param indexes List[str]: Paths to one or more SKA indexes.
-    :param cluster_method str: The linkage or clustering method to use, default to single
-    :param algorithm str: The clustering algorithm to use
-
-    :raises ValueError: raises an exception if the method is not a valid scipy clustering method.
-
-    :return: clustering result in newick format
-    :rtype: str
+    Cluster samples using SKA indexes and return Newick tree.
     """
+
     # validate input samples and cast to path
     idx_paths = [Path(settings.index_dir) / idx["ska_index"] for idx in indexes]
 
+    # Map index name → sample_id
     sample_id_lookup = {
         get_index_name(idx["ska_index"]): idx["sample_id"] 
         for idx in indexes
     }
 
-    # validate cluster method
-    try:
-        method = LinkageMethod(cluster_method)
-    except ValueError as error:
-        msg = f'"{cluster_method}" is not a valid cluster method'
-        LOG.error(
-            "cluster.invalid_method",
-            extra={"cluster_method": cluster_method}
-        )
-        raise ValueError(msg) from error
+    # Validate clustering method (only needed for hierarchical)
+    method: LinkageMethod | None = None
+    if algorithm == "hierarchical":
+        try:
+            method = LinkageMethod(cluster_method)
+        except ValueError as error:
+            LOG.error(
+                "cluster.invalid_method",
+                extra={"cluster_method": cluster_method},
+            )
+            raise ValueError(f'"{cluster_method}" is not a valid cluster method') from error
 
+    elif algorithm != "mst":
+        raise ValueError(f"Unknown clustering algorithm: {algorithm}")
+    
+    # Core pipeline
     with TemporaryDirectory() as tmp_dir:
-        # merge indexes into a single file
-        merged_index = ska.merge(idx_paths, output=Path(tmp_dir).joinpath("merged.skf"))
+        merged_index = ska.merge(
+            idx_paths,
+            output=Path(tmp_dir) / "merged.skf",
+        )
 
-        # align variants and return as multi fasta
-        aln_file = ska.align(merged_index, filter_ambig=True, filter_constant=True)
+        aln_file = ska.align(
+            merged_index,
+            filter_ambig=True,
+            filter_constant=True,
+        )
 
-        # calculate distance between samples from alignment and cluster
-        with open(aln_file, encoding="utf-8") as inpt:
-            aln = AlignIO.read(inpt, "fasta")
+        with open(aln_file, encoding="utf-8") as handle:
+            aln = AlignIO.read(handle, "fasta")
 
-        dm = calc_snv_distance(aln)
-        condensed = dm.to_condensed()
-        names: list[str] = dm.names
-        sample_ids = [sample_id_lookup.get(idx, idx) for idx in names]
+    # Map names after alignment
+    sample_ids = [
+        sample_id_lookup.get(name, name)
+        for name in (aln_i.name for aln_i in aln)
+    ]
 
-        # cluster samples
-        if algorithm == "hierarchical":
-            result = hierarchical_clustering(
-                condensed,
-                sample_ids,
-                method=method,
-            )
-
-        elif algorithm == "mst":
-            result = minimum_spanning_tree_clustering(
-                condensed,
-                sample_ids,
-            )
-
-        else:
-            raise ValueError(f"Unknown clustering algorithm: {algorithm}")
-
-    return result.to_newick()
+    return ska.cluster_alignment(
+        aln,
+        sample_ids,
+        algorithm=algorithm,
+        method=method,
+    )
 
 
 def check_index(file_name: str) -> str | None:

--- a/ska_service/ska_service/tasks.py
+++ b/ska_service/ska_service/tasks.py
@@ -6,10 +6,11 @@ from tempfile import TemporaryDirectory
 from typing import Sequence
 
 from Bio import AlignIO
+from bonsai_libs.clustering import LinkageMethod, hierarchical_clustering, minimum_spanning_tree_clustering
 
 from . import ska
 from .config import settings
-from .ska.cluster import ClusterMethod, calc_snv_distance, to_newick
+from .ska.cluster import calc_snv_distance
 
 LOG = logging.getLogger(__name__)
 
@@ -19,12 +20,17 @@ def get_index_name(index_path: str) -> str:
     return Path(index_path).stem.replace('_ska_index', '')
 
 
-def cluster(indexes: Sequence[dict[str, str]], cluster_method: str = "single") -> str:
+def cluster(
+        indexes: Sequence[dict[str, str]], 
+        cluster_method: str = "single",
+        algorithm: str = "hierarchical",
+    ) -> str:
     """
     Cluster multiple sample on their SNVs using SKA indexes.
 
     :param indexes List[str]: Paths to one or more SKA indexes.
     :param cluster_method str: The linkage or clustering method to use, default to single
+    :param algorithm str: The clustering algorithm to use
 
     :raises ValueError: raises an exception if the method is not a valid scipy clustering method.
 
@@ -41,10 +47,13 @@ def cluster(indexes: Sequence[dict[str, str]], cluster_method: str = "single") -
 
     # validate cluster method
     try:
-        method = ClusterMethod(cluster_method)
+        method = LinkageMethod(cluster_method)
     except ValueError as error:
         msg = f'"{cluster_method}" is not a valid cluster method'
-        LOG.error(msg)
+        LOG.error(
+            "cluster.invalid_method",
+            extra={"cluster_method": cluster_method}
+        )
         raise ValueError(msg) from error
 
     with TemporaryDirectory() as tmp_dir:
@@ -55,14 +64,32 @@ def cluster(indexes: Sequence[dict[str, str]], cluster_method: str = "single") -
         aln_file = ska.align(merged_index, filter_ambig=True, filter_constant=True)
 
         # calculate distance between samples from alignment and cluster
-        with open(aln_file) as inpt:
+        with open(aln_file, encoding="utf-8") as inpt:
             aln = AlignIO.read(inpt, "fasta")
+
         dm = calc_snv_distance(aln)
-        tree, index_names = ska.cluster_distances(dm, method)
-        # lookup sample ids from index names and return newick tree with sample ids as leaf names
-        sample_ids = [sample_id_lookup.get(idx, idx) for idx in index_names]
-        newick_tree = to_newick(tree, "", tree.dist, sample_ids)
-    return newick_tree
+        condensed = dm.to_condensed()
+        names: list[str] = dm.names
+        sample_ids = [sample_id_lookup.get(idx, idx) for idx in names]
+
+        # cluster samples
+        if algorithm == "hierarchical":
+            result = hierarchical_clustering(
+                condensed,
+                sample_ids,
+                method=method,
+            )
+
+        elif algorithm == "mst":
+            result = minimum_spanning_tree_clustering(
+                condensed,
+                sample_ids,
+            )
+
+        else:
+            raise ValueError(f"Unknown clustering algorithm: {algorithm}")
+
+    return result.to_newick()
 
 
 def check_index(file_name: str) -> str | None:

--- a/ska_service/ska_service/tasks.py
+++ b/ska_service/ska_service/tasks.py
@@ -14,6 +14,32 @@ from .config import settings
 LOG = logging.getLogger(__name__)
 
 
+def _parse_cluster_algorithm(algorithm: str) -> ClusteringAlgorithm:
+    """Parse cluster algorithm."""
+
+    try:
+        return ClusteringAlgorithm(algorithm)
+    except ValueError as error:
+        LOG.error(
+            "cluster.invalid_algorithm",
+            extra={"algorithm": algorithm},
+        )
+        raise ValueError(f'"{algorithm}" is not a valid cluster algorithm') from error
+
+
+def _parse_linkage_method(method: str) -> LinkageMethod:
+    """Parse linkate method."""
+
+    try:
+        return LinkageMethod(method)
+    except ValueError as error:
+        LOG.error(
+            "cluster.invalid_method",
+            extra={"cluster_method": method},
+        )
+        raise ValueError(f'"{method}" is not a valid cluster method') from error
+
+
 def get_index_name(index_path: str) -> str:
     """Get the name of the index from the file path."""
     return Path(index_path).stem.replace('_ska_index', '')
@@ -38,25 +64,8 @@ def cluster(
     }
 
     # Validate clustering algorithm and method (only needed for hierarchical)
-    try:
-        algorithm = ClusteringAlgorithm(algorithm)
-    except ValueError as error:
-        LOG.error(
-            "cluster.invalid_algorithm",
-            extra={"algorithm": algorithm},
-        )
-        raise ValueError(f'"{algorithm}" is not a valid cluster algorithm') from error
-
-    method: LinkageMethod | None = None
-    if algorithm == ClusteringAlgorithm.HIERARCHICAL:
-        try:
-            method = LinkageMethod(cluster_method)
-        except ValueError as error:
-            LOG.error(
-                "cluster.invalid_method",
-                extra={"cluster_method": cluster_method},
-            )
-            raise ValueError(f'"{cluster_method}" is not a valid cluster method') from error
+    algorithm = _parse_cluster_algorithm(algorithm)
+    method = _parse_linkage_method(cluster_method) if cluster_method else None
 
     # Core pipeline
     with TemporaryDirectory() as tmp_dir:

--- a/ska_service/ska_service/tasks.py
+++ b/ska_service/ska_service/tasks.py
@@ -6,7 +6,7 @@ from tempfile import TemporaryDirectory
 from typing import Sequence
 
 from Bio import AlignIO
-from bonsai_libs.clustering import LinkageMethod
+from bonsai_libs.clustering import LinkageMethod, ClusteringAlgorithm
 
 from . import ska
 from .config import settings
@@ -37,9 +37,18 @@ def cluster(
         for idx in indexes
     }
 
-    # Validate clustering method (only needed for hierarchical)
+    # Validate clustering algorithm and method (only needed for hierarchical)
+    try:
+        algorithm = ClusteringAlgorithm(algorithm)
+    except ValueError as error:
+        LOG.error(
+            "cluster.invalid_algorithm",
+            extra={"algorithm": algorithm},
+        )
+        raise ValueError(f'"{algorithm}" is not a valid cluster algorithm') from error
+
     method: LinkageMethod | None = None
-    if algorithm == "hierarchical":
+    if algorithm == ClusteringAlgorithm.HIERARCHICAL:
         try:
             method = LinkageMethod(cluster_method)
         except ValueError as error:
@@ -49,9 +58,6 @@ def cluster(
             )
             raise ValueError(f'"{cluster_method}" is not a valid cluster method') from error
 
-    elif algorithm != "mst":
-        raise ValueError(f"Unknown clustering algorithm: {algorithm}")
-    
     # Core pipeline
     with TemporaryDirectory() as tmp_dir:
         merged_index = ska.merge(

--- a/ska_service/tests/test_ska_cluster.py
+++ b/ska_service/tests/test_ska_cluster.py
@@ -1,0 +1,31 @@
+"""Test clustering related functions."""
+
+import pytest
+from Bio.Align import MultipleSeqAlignment
+from Bio.Seq import Seq
+from Bio.SeqRecord import SeqRecord
+
+from ska_service.ska.cluster import calc_snv_distance
+
+
+@pytest.mark.parametrize(
+    "seq_a,seq_b,ignore_gaps,exp_dist",
+    [
+        ("AAAA", "AAAT", False, 1),
+        ("A-AA", "AAAA", False, 1),
+        ("A-AA", "AAAA", True, 0),
+    ],
+)
+def test_calc_snv_distance_wo_ignore_gaps(seq_a, seq_b, ignore_gaps, exp_dist):
+    """Test calculating SNV distance."""
+
+    aln = MultipleSeqAlignment(
+        [
+            SeqRecord(Seq(seq_a), id="A", name="A"),
+            SeqRecord(Seq(seq_b), id="B", name="B"),
+        ]
+    )
+
+    dm = calc_snv_distance(aln, ignore_gaps=ignore_gaps)
+
+    assert dm["A", "B"] == exp_dist


### PR DESCRIPTION
This PR adds the option to cluster SKA and MINHASH sketches using the minimum spanning tree algorithm.

The input structure to the cluster route `/cluster/` was changed to include a `strategy` field which is used to determine how the samples should be clustered.

```python
class ClusterInput(RWModel):  # pylint: disable=too-few-public-methods
    """Input data model for cluster entrypoint."""

    sample_ids: list[str] = Field(..., min_length=2, alias="sampleIds")

    strategy: ClusterStrategy = ClusterStrategy.SINGLE

    model_config = ConfigDict(use_enum_values=False)
```

```python
class ClusterStrategy(StrEnum):
    """Supported clustering strategies."""

    # SDK hierarchical clustering
    SINGLE = "single"
    COMPLETE = "complete"
    AVERAGE = "average"
    WEIGHTED = "weighted"
    CENTROID = "centroid"

    # SDK MST
    MST = "mst"

    # GrapeTree
    MSTREE_V1 = "MSTree"
    MSTREE_V2 = "MSTreeV2"
    NJ = "NJ"
    RAPID_NJ = "RapidNJ"
    NINJA = "ninja"
```

## The following things needs to be updated in the PR

- [ ] Update `/home/mod/developer/bonsai/frontend/bonsai_app/blueprints/cluster/views.py` to pass `strategy` instead of `typing_method`
- [ ] Update similar function in `common.js`
- [ ] Update the cluster button in the GUI to let the user select the clustering method.